### PR TITLE
Fix Dash/Underscore Issue in Package Name

### DIFF
--- a/bw_processing/utils.py
+++ b/bw_processing/utils.py
@@ -22,7 +22,7 @@ def get_version_tuple() -> tuple:
 
     return tuple(
         as_integer(v)
-        for v in importlib.metadata.version("bw_processing")
+        for v in importlib.metadata.version("bw-processing")
         .strip()
         .split(".")
     )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,11 +7,16 @@ import pytest
 
 from bw_processing.errors import InvalidName
 from bw_processing.utils import (
+    get_version_tuple,
     check_name,
     check_suffix,
     dictionary_formatter,
     load_bytes,
 )
+
+
+def test_get_version_tuple():
+    assert isinstance(get_version_tuple(), tuple)
 
 
 def test_load_bytes():


### PR DESCRIPTION
In the utility function

```
def get_version_tuple() -> tuple:
    """Returns version as (major, minor, micro)."""

    def as_integer(version_str: str) -> Union[int, str]:
        try:
            return int(version_str)
        except ValueError:
            return version_str

    return tuple(
        as_integer(v)
        for v in importlib.metadata.version("bw-processing")
        .strip()
        .split(".")
    )
```

having _either_ `bw-processing` or `bw_processing` in the source code of the utility function works exactly the same (tested locally on macOS):

```
>>> import bw_processing as bp
>>> bp.utils.get_version_tuple()
(0, 8, 3)
```

However, it is possible that this is not the case during the build process of the JupyterLite site (cf. https://github.com/emscripten-forge/recipes/pull/616).

@cmutel changed the distribution name of the package to `bw-processing` in September 2022 ([changelog entry](https://github.com/brightway-lca/bw_processing/blob/version-information-fix/CHANGES.md#083---2022-09-15)).

My guess is that this fix might resolve the `empack` build issues we've been experiencing.