### PR TITLE
Minor misc fixes for github actions and readme

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -15,6 +15,7 @@ on:
       - "**.ya?ml" # captures both .yml and .yaml
       - "LICENSE"
       - ".gitignore"
+      - "README.md"
   pull_request:
     branches: [main, develop]
     types: [opened, reopened] # excludes syncronize to avoid redundant trigger from commits on PRs
@@ -33,10 +34,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        py-version: ["3.8", "3.9", "3.10", "3.11"]
+        py-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
-      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4
+      - uses: actions/checkout@v4
 
       # general Python setup
       - name: Set up Python ${{ matrix.py-version }}

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -25,6 +25,7 @@ on:
       - "**.ya?ml"
       - "LICENSE"
       - ".gitignore"
+      - "README.md"
   workflow_dispatch: # also allow manual trigger, for testing purposes
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Library for storing numeric data for use in matrix-based calculations. Designed 
 [![License](https://img.shields.io/pypi/l/bw-processing)][license]
 
 [![Read the documentation at https://bw-processing.readthedocs.io/](https://img.shields.io/readthedocs/bw-processing/latest.svg?label=Read%20the%20Docs)][read the docs]
-[![Tests](https://github.com/brightway-lca/bw-processing/actions/workflows/python-test.yml/badge.svg)][tests]
+[![Testing](https://github.com/brightway-lca/bw_processing/actions/workflows/python-test.yml/badge.svg)][tests]
 [![Codecov](https://codecov.io/gh/brightway-lca/bw-processing/branch/main/graph/badge.svg)][codecov]
 
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)][pre-commit]
@@ -16,7 +16,7 @@ Library for storing numeric data for use in matrix-based calculations. Designed 
 
 [pypi status]: https://pypi.org/project/bw-processing/
 [read the docs]: https://bw-processing.readthedocs.io/
-[tests]: https://github.com/brightway-lca/bw-processing/actions?workflow=Tests
+[tests]: https://github.com/brightway-lca/bw_processing/actions/workflows/python-test.yml
 [codecov]: https://app.codecov.io/gh/brightway-lca/bw-processing
 [pre-commit]: https://github.com/pre-commit/pre-commit
 [black]: https://github.com/psf/black


### PR DESCRIPTION
misc various infra fixes:

+ ignore updates to README when running tests
+ fix testing badge
+ use recommended way of referencing checkout github action ("@v4")
+ add python 3.12 for testing.