### PR TITLE
Add MatrixEntry dataclass and high-level entries API

### DIFF
--- a/bw_processing/__init__.py
+++ b/bw_processing/__init__.py
@@ -5,6 +5,7 @@ __all__ = (
     "clean_datapackage_name",
     "create_array",
     "create_datapackage",
+    "create_datapackage_from_entries",
     "create_structured_array",
     "Datapackage",
     "DatapackageBase",
@@ -15,6 +16,7 @@ __all__ = (
     "generic_zipfile_filesystem",
     "INDICES_DTYPE",
     "load_datapackage",
+    "MatrixEntry",
     "MatrixSerializeFormat",
     "md5",
     "merge_datapackages_with_mask",
@@ -43,6 +45,7 @@ from .examples import examples_dir
 from .filesystem import clean_datapackage_name, md5, safe_filename
 from .indexing import reindex, reset_index
 from .io_helpers import generic_directory_filesystem, generic_zipfile_filesystem
+from .matrix_entry import MatrixEntry, create_datapackage_from_entries
 from .merging import merge_datapackages_with_mask
 from .proxies import UndefinedInterface
 from .unique_fields import as_unique_attributes, as_unique_attributes_dataframe

--- a/bw_processing/__init__.py
+++ b/bw_processing/__init__.py
@@ -17,6 +17,7 @@ __all__ = (
     "INDICES_DTYPE",
     "load_datapackage",
     "MatrixEntry",
+    "MatrixName",
     "MatrixSerializeFormat",
     "md5",
     "merge_datapackages_with_mask",
@@ -45,7 +46,7 @@ from .examples import examples_dir
 from .filesystem import clean_datapackage_name, md5, safe_filename
 from .indexing import reindex, reset_index
 from .io_helpers import generic_directory_filesystem, generic_zipfile_filesystem
-from .matrix_entry import MatrixEntry, create_datapackage_from_entries
+from .matrix_entry import MatrixEntry, MatrixName, create_datapackage_from_entries
 from .merging import merge_datapackages_with_mask
 from .proxies import UndefinedInterface
 from .unique_fields import as_unique_attributes, as_unique_attributes_dataframe

--- a/bw_processing/datapackage.py
+++ b/bw_processing/datapackage.py
@@ -1,8 +1,12 @@
 import datetime
 import uuid
+import warnings
 from abc import ABC
 from functools import partial
-from typing import Any, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+
+if TYPE_CHECKING:
+    from .matrix_entry import MatrixEntry
 
 import numpy as np
 import pandas as pd
@@ -446,6 +450,30 @@ class Datapackage(DatapackageBase):
             distributions_array=distributions_array,
             matrix_serialize_format_type=matrix_serialize_format_type,
             **kwargs,
+        )
+
+    def add_entries(
+        self,
+        *,
+        matrix: str,
+        entries: list["MatrixEntry"],
+        name: Optional[str] = None,
+    ) -> None:
+        """Add matrix data from a list of :class:`MatrixEntry` objects.
+
+        High-level convenience method that does not require working directly
+        with NumPy arrays.
+
+        Args:
+            matrix: Name of the target matrix (e.g. ``"technosphere"``).
+            entries: List of :class:`.MatrixEntry` instances.
+            name: Optional resource group name; auto-generated if omitted.
+        """
+        self.add_persistent_vector_from_iterator(
+            matrix=matrix,
+            name=name,
+            dict_iterator=(e.as_dict() for e in entries),
+            nrows=len(entries),
         )
 
     def add_persistent_vector(
@@ -1091,6 +1119,10 @@ def load_datapackage(
 def simple_graph(data: dict, fs: Optional[AbstractFileSystem] = None, **metadata) -> Datapackage:
     """Easy creation of simple datapackages with only persistent vectors.
 
+    .. deprecated::
+        Use :func:`bw_processing.matrix_entry.create_datapackage_from_entries` with
+        :class:`bw_processing.matrix_entry.MatrixEntry` objects instead.
+
     Args:
         * data: is a dictionary.
             The data dictionary has the form::
@@ -1111,6 +1143,11 @@ def simple_graph(data: dict, fs: Optional[AbstractFileSystem] = None, **metadata
         the datapackage.
 
     """
+    warnings.warn(
+        "simple_graph is deprecated; use create_datapackage_from_entries with MatrixEntry objects instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     dp = create_datapackage(fs=fs or DictFS(), **metadata)
     for key, value in data.items():
         indices_array = np.array([row[:2] for row in value], dtype=INDICES_DTYPE)

--- a/bw_processing/matrix_entry.py
+++ b/bw_processing/matrix_entry.py
@@ -1,0 +1,93 @@
+import dataclasses
+import math
+from typing import Optional
+
+from fsspec import AbstractFileSystem
+
+
+@dataclasses.dataclass(frozen=True)
+class MatrixEntry:
+    """A single entry destined for a matrix cell.
+
+    Multiple instances with the same (row, col) are summed during matrix
+    construction, so this is not necessarily the final cell value.
+
+    Field names and defaults match those expected by bw_processing's
+    ``dictionary_formatter``. Convert to a plain dict with ``as_dict()``
+    before passing to bw_processing internals.
+
+    Args:
+        row: Integer row index in the target matrix.
+        col: Integer column index in the target matrix.
+        amount: The numeric value to place at (row, col).
+        flip: If True, negate the value when building the matrix.
+        uncertainty_type: Probability distribution type (0 = no uncertainty,
+            2 = lognormal, 3 = normal, etc. — see stats_arrays for full list).
+        loc: Distribution location parameter. For lognormal this is the log
+            of the median; defaults to NaN (no uncertainty).
+        scale: Distribution scale parameter (e.g. standard deviation).
+        shape: Distribution shape parameter.
+        minimum: Lower bound for distribution sampling.
+        maximum: Upper bound for distribution sampling.
+        negative: Whether the underlying value is negative.
+    """
+
+    row: int
+    col: int
+    amount: float
+    flip: bool = False
+    uncertainty_type: int = 0
+    loc: float = math.nan
+    scale: float = math.nan
+    shape: float = math.nan
+    minimum: float = math.nan
+    maximum: float = math.nan
+    negative: bool = False
+
+    def as_dict(self) -> dict:
+        return dataclasses.asdict(self)
+
+
+def create_datapackage_from_entries(
+    data: dict,
+    fs: Optional[AbstractFileSystem] = None,
+    **metadata,
+):
+    """Create a datapackage from a dictionary of :class:`MatrixEntry` lists.
+
+    This is the recommended high-level entry point for building datapackages
+    without working directly with NumPy arrays.
+
+    Args:
+        data: Dictionary mapping matrix names to lists of :class:`MatrixEntry`
+            objects, e.g.::
+
+                {
+                    "technosphere": [
+                        MatrixEntry(row=1, col=4, amount=2.5),
+                        MatrixEntry(row=2, col=5, amount=7.0, flip=True),
+                    ],
+                    "biosphere": [
+                        MatrixEntry(row=10, col=4, amount=0.3),
+                    ],
+                }
+
+        fs: Optional filesystem. Defaults to an in-memory filesystem.
+        **metadata: Additional keyword arguments passed to
+            :func:`create_datapackage` (e.g. ``name``, ``id_``).
+
+    Returns:
+        A :class:`Datapackage` instance.
+    """
+    # Import here to avoid circular imports at module level
+    from .datapackage import create_datapackage
+    from morefs.dict import DictFS
+
+    dp = create_datapackage(fs=fs or DictFS(), **metadata)
+    for matrix_name, entries in data.items():
+        dp.add_entries(
+            matrix=matrix_name,
+            entries=entries,
+            name=f"{matrix_name}-data",
+        )
+    return dp

--- a/bw_processing/matrix_entry.py
+++ b/bw_processing/matrix_entry.py
@@ -1,5 +1,27 @@
 import dataclasses
 import math
+from enum import Enum
+
+
+class MatrixName(str, Enum):
+    """Standard matrix names used in Brightway.
+
+    Because this is a ``str`` enum, members can be used anywhere a plain
+    string is accepted — no ``.value`` needed::
+
+        MatrixEntry(row=1, col=4, amount=2.5)  # inside a dict keyed by MatrixName
+        dp.add_entries(matrix=MatrixName.technosphere, entries=[...])
+
+    Derived libraries may define additional matrices as plain strings;
+    these three cover the core Brightway LCA workflow.
+    """
+
+    technosphere = "technosphere_matrix"
+    biosphere = "biosphere_matrix"
+    characterization = "characterization_matrix"
+
+    def __str__(self) -> str:
+        return self.value
 
 
 @dataclasses.dataclass(frozen=True)
@@ -57,14 +79,16 @@ def create_datapackage_from_entries(
 
     Args:
         data: Dictionary mapping matrix names to lists of :class:`MatrixEntry`
-            objects, e.g.::
+            objects. Use :class:`MatrixName` members as keys for the standard
+            Brightway matrices; derived libraries may use plain strings for
+            additional matrices::
 
                 {
-                    "technosphere": [
+                    MatrixName.technosphere: [
                         MatrixEntry(row=1, col=4, amount=2.5),
                         MatrixEntry(row=2, col=5, amount=7.0, flip=True),
                     ],
-                    "biosphere": [
+                    MatrixName.biosphere: [
                         MatrixEntry(row=10, col=4, amount=0.3),
                     ],
                 }

--- a/bw_processing/matrix_entry.py
+++ b/bw_processing/matrix_entry.py
@@ -20,7 +20,7 @@ class MatrixEntry:
         row: Integer row index in the target matrix.
         col: Integer column index in the target matrix.
         amount: The numeric value to place at (row, col).
-        flip: If True, negate the value when building the matrix.
+        flip: If True, multiply the value by -1 when building the matrix.
         uncertainty_type: Probability distribution type (0 = no uncertainty,
             2 = lognormal, 3 = normal, etc. — see stats_arrays for full list).
         loc: Distribution location parameter. For lognormal this is the log

--- a/bw_processing/matrix_entry.py
+++ b/bw_processing/matrix_entry.py
@@ -1,8 +1,5 @@
 import dataclasses
 import math
-from typing import Optional
-
-from fsspec import AbstractFileSystem
 
 
 @dataclasses.dataclass(frozen=True)
@@ -50,7 +47,7 @@ class MatrixEntry:
 
 def create_datapackage_from_entries(
     data: dict,
-    fs: Optional[AbstractFileSystem] = None,
+    fs=None,
     **metadata,
 ):
     """Create a datapackage from a dictionary of :class:`MatrixEntry` lists.
@@ -79,11 +76,9 @@ def create_datapackage_from_entries(
     Returns:
         A :class:`Datapackage` instance.
     """
-    # Import here to avoid circular imports at module level
     from .datapackage import create_datapackage
-    from morefs.dict import DictFS
 
-    dp = create_datapackage(fs=fs or DictFS(), **metadata)
+    dp = create_datapackage(fs=fs, **metadata)
     for matrix_name, entries in data.items():
         dp.add_entries(
             matrix=matrix_name,

--- a/tests/test_matrix_entry.py
+++ b/tests/test_matrix_entry.py
@@ -1,0 +1,158 @@
+import math
+import warnings
+
+import numpy as np
+import pytest
+
+from bw_processing import (
+    MatrixEntry,
+    MatrixName,
+    create_datapackage_from_entries,
+    simple_graph,
+)
+from bw_processing.constants import UNCERTAINTY_DTYPE
+
+
+class TestMatrixName:
+    def test_values(self):
+        assert MatrixName.technosphere == "technosphere_matrix"
+        assert MatrixName.biosphere == "biosphere_matrix"
+        assert MatrixName.characterization == "characterization_matrix"
+
+    def test_str(self):
+        assert str(MatrixName.technosphere) == "technosphere_matrix"
+
+    def test_fstring(self):
+        assert f"{MatrixName.biosphere}" == "biosphere_matrix"
+
+    def test_usable_as_dict_key(self):
+        d = {MatrixName.technosphere: [1, 2, 3]}
+        assert d["technosphere_matrix"] == [1, 2, 3]
+
+
+class TestMatrixEntry:
+    def test_required_fields(self):
+        e = MatrixEntry(row=1, col=2, amount=3.0)
+        assert e.row == 1
+        assert e.col == 2
+        assert e.amount == 3.0
+
+    def test_defaults(self):
+        e = MatrixEntry(row=1, col=2, amount=3.0)
+        assert e.flip is False
+        assert e.uncertainty_type == 0
+        assert e.negative is False
+        assert math.isnan(e.loc)
+        assert math.isnan(e.scale)
+        assert math.isnan(e.shape)
+        assert math.isnan(e.minimum)
+        assert math.isnan(e.maximum)
+
+    def test_frozen(self):
+        e = MatrixEntry(row=1, col=2, amount=3.0)
+        with pytest.raises(Exception):
+            e.amount = 99.0
+
+    def test_as_dict_keys(self):
+        e = MatrixEntry(row=1, col=2, amount=3.0)
+        d = e.as_dict()
+        assert set(d.keys()) == {
+            "row", "col", "amount", "flip", "uncertainty_type",
+            "loc", "scale", "shape", "minimum", "maximum", "negative",
+        }
+
+    def test_as_dict_values(self):
+        e = MatrixEntry(row=5, col=10, amount=2.5, flip=True, uncertainty_type=2,
+                        loc=0.9, scale=0.1, negative=True)
+        d = e.as_dict()
+        assert d["row"] == 5
+        assert d["col"] == 10
+        assert d["amount"] == 2.5
+        assert d["flip"] is True
+        assert d["uncertainty_type"] == 2
+        assert d["loc"] == pytest.approx(0.9)
+        assert d["scale"] == pytest.approx(0.1)
+        assert d["negative"] is True
+
+
+class TestCreateDatapackageFromEntries:
+    def test_basic(self):
+        entries = [
+            MatrixEntry(row=1, col=4, amount=2.0),
+            MatrixEntry(row=2, col=5, amount=7.0),
+        ]
+        dp = create_datapackage_from_entries({MatrixName.technosphere: entries})
+        assert "technosphere_matrix-data" in dp.groups
+
+    def test_multiple_matrices(self):
+        dp = create_datapackage_from_entries({
+            MatrixName.technosphere: [MatrixEntry(row=1, col=2, amount=1.0)],
+            MatrixName.biosphere: [MatrixEntry(row=3, col=4, amount=0.5)],
+        })
+        groups = list(dp.groups.keys())
+        assert "technosphere_matrix-data" in groups
+        assert "biosphere_matrix-data" in groups
+
+    def test_plain_string_matrix_name(self):
+        dp = create_datapackage_from_entries({
+            "custom_matrix": [MatrixEntry(row=1, col=2, amount=1.0)],
+        })
+        assert "custom_matrix-data" in dp.groups
+
+    def test_data_values(self):
+        entries = [
+            MatrixEntry(row=1, col=4, amount=2.0),
+            MatrixEntry(row=2, col=5, amount=7.0),
+            MatrixEntry(row=3, col=6, amount=12.0),
+        ]
+        dp = create_datapackage_from_entries({MatrixName.technosphere: entries})
+        group = dp.groups["technosphere_matrix-data"]
+
+        data_resource = next(r for r in group.resources if r["kind"] == "data")
+        data_idx = dp.resources.index(data_resource)
+        data = dp.data[data_idx]
+        assert set(data) == {2.0, 7.0, 12.0}
+
+    def test_flip_stored(self):
+        entries = [
+            MatrixEntry(row=1, col=4, amount=2.0, flip=True),
+            MatrixEntry(row=2, col=5, amount=7.0, flip=False),
+        ]
+        dp = create_datapackage_from_entries({MatrixName.technosphere: entries})
+        group = dp.groups["technosphere_matrix-data"]
+
+        flip_resource = next(r for r in group.resources if r["kind"] == "flip")
+        flip_idx = dp.resources.index(flip_resource)
+        flip = dp.data[flip_idx]
+        assert flip.sum() == 1
+
+    def test_uncertainty_stored(self):
+        entries = [
+            MatrixEntry(row=1, col=4, amount=2.0, uncertainty_type=2, loc=0.7, scale=0.1),
+            MatrixEntry(row=2, col=5, amount=7.0),
+        ]
+        dp = create_datapackage_from_entries({MatrixName.technosphere: entries})
+        group = dp.groups["technosphere_matrix-data"]
+
+        dist_resource = next(r for r in group.resources if r["kind"] == "distributions")
+        dist_idx = dp.resources.index(dist_resource)
+        dist = dp.data[dist_idx]
+        assert dist.dtype == np.dtype(UNCERTAINTY_DTYPE)
+        uncertainty_types = set(dist["uncertainty_type"])
+        assert 2 in uncertainty_types
+
+    def test_metadata_passed_through(self):
+        dp = create_datapackage_from_entries(
+            {MatrixName.technosphere: [MatrixEntry(row=1, col=2, amount=1.0)]},
+            name="my-package",
+        )
+        assert dp.metadata["name"] == "my-package"
+
+class TestSimpleGraphDeprecation:
+    def test_deprecation_warning(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            simple_graph({"technosphere": [(1, 4, 2.5)]})
+        assert len(w) == 1
+        assert issubclass(w[0].category, DeprecationWarning)
+        assert "create_datapackage_from_entries" in str(w[0].message)


### PR DESCRIPTION
## Summary

- Adds a `MatrixEntry` frozen dataclass (adapted from `bw_eotw`) with named fields for all matrix and uncertainty parameters, making it easy to construct datapackage data without touching NumPy directly
- Adds `Datapackage.add_entries(matrix, entries, name=None)` method that accepts a `list[MatrixEntry]` and delegates to the existing `add_persistent_vector_from_iterator` pipeline
- Adds `create_datapackage_from_entries(data, fs=None, **metadata)` top-level function as the recommended replacement for `simple_graph`
- Deprecates `simple_graph` with a `DeprecationWarning` pointing to the new API
- Exports `MatrixEntry` and `create_datapackage_from_entries` from the package root

## Example usage

```python
from bw_processing import MatrixEntry, create_datapackage_from_entries

dp = create_datapackage_from_entries({
    "technosphere": [
        MatrixEntry(row=1, col=4, amount=2.5),
        MatrixEntry(row=2, col=5, amount=7.0, flip=True),
        MatrixEntry(row=3, col=6, amount=12.0, uncertainty_type=2, loc=2.485, scale=0.1),
    ],
    "biosphere": [
        MatrixEntry(row=10, col=4, amount=0.3),
    ],
}, name="my-model")
```

## Test plan

- [x] All 108 existing tests pass
- [x] `MatrixEntry` construction and `as_dict()` verified
- [x] `create_datapackage_from_entries` produces correct groups and resources
- [x] `simple_graph` emits `DeprecationWarning`
- [ ] Add dedicated tests for `MatrixEntry` and `add_entries`