### PR TITLE
Release 1.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # `bw_processing` Changelog
 
+## [1.1] - 2026-04-26
+
+* [PR #79: Add `MatrixEntry` dataclass, `MatrixName` StrEnum, and `create_datapackage_from_entries` high-level API](https://github.com/brightway-lca/bw_processing/pull/79)
+* [PR #80: Convert to `src` layout with absolute imports and CI fixes](https://github.com/brightway-lca/bw_processing/pull/80)
+* [PR #81: Fix parquet tests using `pathlib.Path` as context manager](https://github.com/brightway-lca/bw_processing/pull/81)
+
 # [1.0] - 2024-08-19
 
 * Move default indices type to 64 bit integers

--- a/src/bw_processing/__init__.py
+++ b/src/bw_processing/__init__.py
@@ -29,7 +29,7 @@ __all__ = (
     "UndefinedInterface",
 )
 
-__version__ = "1.0"
+__version__ = "1.1"
 
 
 from bw_processing.array_creation import create_array, create_structured_array


### PR DESCRIPTION
## Summary

- Bump version to `1.1`
- Add changelog entry for the three PRs merged since 1.0:
  - PR #79: `MatrixEntry` dataclass, `MatrixName` StrEnum, and `create_datapackage_from_entries` high-level API
  - PR #80: Convert to `src` layout with absolute imports and CI fixes
  - PR #81: Fix parquet tests using `pathlib.Path` as context manager

## Test plan

- [ ] CI passes
- [ ] `bw_processing.__version__` returns `"1.1"` after install