### PR TITLE
Fix MatrixEntry.loc defaulting to NaN for no-uncertainty types

### DIFF
--- a/src/bw_processing/matrix_entry.py
+++ b/src/bw_processing/matrix_entry.py
@@ -63,6 +63,16 @@ class MatrixEntry:
     maximum: float = math.nan
     negative: bool = False
 
+    def __post_init__(self):
+        if self.uncertainty_type in (0, 1):
+            if math.isnan(self.loc):
+                object.__setattr__(self, "loc", self.amount)
+            elif self.loc != self.amount:
+                raise ValueError(
+                    f"uncertainty_type {self.uncertainty_type} requires loc == amount, "
+                    f"got loc={self.loc} but amount={self.amount}"
+                )
+
     def as_dict(self) -> dict:
         return dataclasses.asdict(self)
 

--- a/src/bw_processing/matrix_entry.py
+++ b/src/bw_processing/matrix_entry.py
@@ -2,6 +2,8 @@ import dataclasses
 import math
 from enum import Enum
 
+from stats_arrays import NoUncertainty, UndefinedUncertainty
+
 
 class MatrixName(str, Enum):
     """Standard matrix names used in Brightway.
@@ -64,7 +66,7 @@ class MatrixEntry:
     negative: bool = False
 
     def __post_init__(self):
-        if self.uncertainty_type in (0, 1):
+        if self.uncertainty_type in (UndefinedUncertainty.id, NoUncertainty.id):
             if math.isnan(self.loc):
                 object.__setattr__(self, "loc", self.amount)
             elif self.loc != self.amount:

--- a/src/bw_processing/matrix_entry.py
+++ b/src/bw_processing/matrix_entry.py
@@ -2,7 +2,11 @@ import dataclasses
 import math
 from enum import Enum
 
-from stats_arrays import NoUncertainty, UndefinedUncertainty
+try:
+    from stats_arrays import NoUncertainty, UndefinedUncertainty
+    _NO_UNCERTAINTY_IDS = (UndefinedUncertainty.id, NoUncertainty.id)
+except ImportError:
+    _NO_UNCERTAINTY_IDS = (0, 1)
 
 
 class MatrixName(str, Enum):
@@ -66,7 +70,7 @@ class MatrixEntry:
     negative: bool = False
 
     def __post_init__(self):
-        if self.uncertainty_type in (UndefinedUncertainty.id, NoUncertainty.id):
+        if self.uncertainty_type in _NO_UNCERTAINTY_IDS:
             if math.isnan(self.loc):
                 object.__setattr__(self, "loc", self.amount)
             elif self.loc != self.amount:

--- a/tests/test_matrix_entry.py
+++ b/tests/test_matrix_entry.py
@@ -42,11 +42,31 @@ class TestMatrixEntry:
         assert e.flip is False
         assert e.uncertainty_type == 0
         assert e.negative is False
-        assert math.isnan(e.loc)
+        assert e.loc == pytest.approx(3.0)
         assert math.isnan(e.scale)
         assert math.isnan(e.shape)
         assert math.isnan(e.minimum)
         assert math.isnan(e.maximum)
+
+    def test_loc_set_to_amount_for_no_uncertainty(self):
+        e = MatrixEntry(row=1, col=2, amount=5.0)
+        assert e.loc == pytest.approx(5.0)
+
+    def test_explicit_loc_matching_amount_accepted(self):
+        e = MatrixEntry(row=1, col=2, amount=5.0, uncertainty_type=0, loc=5.0)
+        assert e.loc == pytest.approx(5.0)
+
+    def test_loc_mismatch_raises_for_uncertainty_type_0(self):
+        with pytest.raises(ValueError, match="loc == amount"):
+            MatrixEntry(row=1, col=2, amount=5.0, uncertainty_type=0, loc=9.9)
+
+    def test_loc_mismatch_raises_for_uncertainty_type_1(self):
+        with pytest.raises(ValueError, match="loc == amount"):
+            MatrixEntry(row=1, col=2, amount=5.0, uncertainty_type=1, loc=9.9)
+
+    def test_loc_not_set_when_uncertainty_type_nonzero(self):
+        e = MatrixEntry(row=1, col=2, amount=5.0, uncertainty_type=2)
+        assert math.isnan(e.loc)
 
     def test_frozen(self):
         e = MatrixEntry(row=1, col=2, amount=3.0)


### PR DESCRIPTION
## Summary

- When `uncertainty_type` is 0 or 1 (nouncertainty / undefined), `MatrixEntry` now sets `loc = amount` on instantiation if `loc` is not explicitly provided — fixing sampling returning NaN instead of the actual value.
- Raises `ValueError` if an explicit `loc` is given that differs from `amount` for these types, since that combination is nonsensical.

## Test plan

- [ ] `test_loc_set_to_amount_for_no_uncertainty` — `loc` auto-set to `amount` when omitted
- [ ] `test_explicit_loc_matching_amount_accepted` — explicit `loc == amount` accepted without error
- [ ] `test_loc_mismatch_raises_for_uncertainty_type_0` — mismatched `loc` raises `ValueError`
- [ ] `test_loc_mismatch_raises_for_uncertainty_type_1` — same for type 1
- [ ] `test_loc_not_set_when_uncertainty_type_nonzero` — other uncertainty types unaffected

Closes #83