### PR TITLE
Release 1.1.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # `bw_processing` Changelog
 
+## [1.1.1] - 2026-04-27
+
+* [PR #84: Fix `MatrixEntry.loc` defaulting to NaN for no-uncertainty types; raise `ValueError` on inconsistent `loc`/`amount`; use `stats_arrays` class IDs with integer fallback](https://github.com/brightway-lca/bw_processing/pull/84)
+
 ## [1.1] - 2026-04-26
 
 * [PR #79: Add `MatrixEntry` dataclass, `MatrixName` StrEnum, and `create_datapackage_from_entries` high-level API](https://github.com/brightway-lca/bw_processing/pull/79)

--- a/src/bw_processing/__init__.py
+++ b/src/bw_processing/__init__.py
@@ -29,7 +29,7 @@ __all__ = (
     "UndefinedInterface",
 )
 
-__version__ = "1.1"
+__version__ = "1.1.1"
 
 
 from bw_processing.array_creation import create_array, create_structured_array


### PR DESCRIPTION
## Summary

- Bump version to 1.1.1
- Update changelog

## Changes since 1.1

- [PR #84](https://github.com/brightway-lca/bw_processing/pull/84): Fix `MatrixEntry.loc` defaulting to NaN when `uncertainty_type` is 0 or 1 (undefined/no uncertainty) — `loc` is now set to `amount` on instantiation. Also raises `ValueError` if an explicit `loc` is given that differs from `amount` for these types. Uses `stats_arrays` class IDs where available, with integer fallback.