### PR TITLE
Bump version to 1.2 and update changelog

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # `bw_processing` Changelog
 
+## [1.2] - 2026-05-26
+
+* [PR #87: Default to `ZIP_DEFLATED` compression in `generic_zipfile_filesystem`; index arrays compress to ~10% of original size, reducing large datapackages ~4×](https://github.com/brightway-lca/bw_processing/pull/87)
+
 ## [1.1.1] - 2026-04-27
 
 * [PR #84: Fix `MatrixEntry.loc` defaulting to NaN for no-uncertainty types; raise `ValueError` on inconsistent `loc`/`amount`; use `stats_arrays` class IDs with integer fallback](https://github.com/brightway-lca/bw_processing/pull/84)

--- a/src/bw_processing/__init__.py
+++ b/src/bw_processing/__init__.py
@@ -29,7 +29,7 @@ __all__ = (
     "UndefinedInterface",
 )
 
-__version__ = "1.1.1"
+__version__ = "1.2"
 
 
 from bw_processing.array_creation import create_array, create_structured_array


### PR DESCRIPTION
## Summary

- Bumps `__version__` from `1.1.1` to `1.2`
- Adds changelog entry for `1.2` referencing PR #87 (ZIP_DEFLATED compression)

## Changes in this release

- [PR #87](https://github.com/brightway-lca/bw_processing/pull/87): `generic_zipfile_filesystem` now defaults to `ZIP_DEFLATED` compression. Index arrays compress to ~10% of their original size, reducing large datapackages ~4× on disk and over the wire.