### PR TITLE
Add scale_array support for per-exchange multiplicative rescaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The [Brightway LCA framework](https://brightway.dev/) has stored data used in co
 * **Dynamic data sources**. Instead of requiring that data for matrix construction be present and savedd on disk, it can now be generated dynamically, either through code running locally or on another computer system. This is a big step towards embeddding life cycle assessment in a web of environmental models.
 * **Use [fsspec](https://filesystem-spec.readthedocs.io/en/latest/) for file IO**. The use of this library allows for data packages to be stored on your local computer, or on [many logical or virtual file systems](https://docs.pyfilesystem.org/en/latest/guide.html).
 * **Simpler handling of numeric values whose sign should be flipped**. Sometimes it is more convenient to specify positive numbers in dataset definitions, even though such numbers should be negative when inserted into the resulting matrices. For example, in the technosphere matrix in life cycle assessment, products produced are positive and products consumed are negative, though both values are given as positive in datasets. Brightway used to use a type mapping dictionary to indicate which values in a matrix should have their sign flipped after insertion. Such mapping dictionaries are brittle and inelegant. `bw_processing` uses an optional boolean vector, called `flip`, to indicate if any values should be flipped.
+* **Per-exchange multiplicative scaling**. An optional float vector, called `scale`, can be attached to any resource group. Each element is a multiplicative factor applied to the corresponding data value — whether static or sampled stochastically — before it is inserted into the matrix. Typical uses are allocation factors and unit conversions. A value of `1.0` leaves the data unchanged.
 * **Separation of uncertainty distribution parameters from other data**. Fitting data to a [probability density function](https://en.wikipedia.org/wiki/Probability_density_function) (PDF), or an estimate of such a PDF, is only one approach to quantitative uncertainty analysis. We would like to support other approaches, including [direct sampling from real data](https://github.com/PascalLesage/presamples/). Therefore, uncertainty distribution parameters are stored separately,  only loaded if needed, and are only one way to express quantitative uncertainty.
 
 ## Concepts
@@ -144,6 +145,36 @@ data_obj, resource_metadata = my_dp.get_resource("some-interface")
 print(data_obj.url)
 >>> "example.com"
 ```
+
+### Scale arrays
+
+Any resource group (persistent or dynamic, vector or array) can carry an optional `scale_array`: a one-dimensional float array of the same length as `indices_array`. Each element is a multiplicative factor applied to the corresponding data value before it is inserted into the matrix. The factor is applied to both static and stochastically-sampled values. A value of `1.0` leaves the data unchanged.
+
+Typical use cases:
+
+* **Allocation factors** — when a process produces multiple products, the exchange amounts must be partitioned between them. Storing the allocation coefficients as a `scale_array` keeps them alongside the data they modify without requiring a separate processing step.
+* **Unit conversions** — when source data is expressed in a unit that differs from the matrix convention, a constant conversion factor can be stored as a `scale_array` rather than baked into every data value.
+
+```python
+import numpy as np
+from bw_processing import create_datapackage
+from bw_processing.constants import INDICES_DTYPE
+
+dp = create_datapackage()
+indices_array = np.array([(1, 4), (2, 5), (3, 6)], dtype=INDICES_DTYPE)
+data_array = np.array([100.0, 200.0, 300.0])
+scale_array = np.array([0.6, 1.0, 0.4])  # e.g. allocation factors
+
+dp.add_persistent_vector(
+    matrix="technosphere",
+    name="my-process",
+    indices_array=indices_array,
+    data_array=data_array,
+    scale_array=scale_array,
+)
+```
+
+The stored resource has `kind="scale"` and can be retrieved via `dp.get_resource("my-process.scale")`. The `scale_array` must be a float dtype (`float32` or `float64`); passing an integer array raises `WrongDatatype`.
 
 ### Policies
 

--- a/src/bw_processing/datapackage.py
+++ b/src/bw_processing/datapackage.py
@@ -485,11 +485,20 @@ class Datapackage(DatapackageBase):
         data_array: Optional[np.ndarray] = None,
         flip_array: Optional[np.ndarray] = None,
         distributions_array: Optional[np.ndarray] = None,
+        scale_array: Optional[np.ndarray] = None,
         keep_proxy: bool = False,
         matrix_serialize_format_type: Optional[MatrixSerializeFormat] = None,
         **kwargs,
     ) -> None:
-        """ """
+        """Add a persistent vector resource group to the datapackage.
+
+        ``scale_array`` is an optional 1-D float array of the same length as
+        ``indices_array``.  Each element is a multiplicative factor applied to
+        the corresponding data value — whether static or stochastic — before
+        the value is inserted into the matrix.  Typical uses are allocation
+        factors and unit conversions.  A value of ``1.0`` leaves the data
+        unchanged.
+        """
         self._prepare_modifications()
 
         # Check lengths
@@ -580,6 +589,15 @@ class Datapackage(DatapackageBase):
                     meta_type="generic",
                     **kwargs,
                 )
+        if scale_array is not None:
+            self._add_scale_array_resource(
+                scale_array=scale_array,
+                indices_array=indices_array,
+                name=name,
+                keep_proxy=keep_proxy,
+                matrix_serialize_format_type=matrix_serialize_format_type,
+                **kwargs,
+            )
 
     def add_persistent_array(
         self,
@@ -589,11 +607,20 @@ class Datapackage(DatapackageBase):
         indices_array: np.ndarray,
         name: Optional[str] = None,
         flip_array: Optional[np.ndarray] = None,
+        scale_array: Optional[np.ndarray] = None,
         keep_proxy: bool = False,
         matrix_serialize_format_type: Optional[MatrixSerializeFormat] = None,
         **kwargs,
     ) -> None:
-        """ """
+        """Add a persistent array resource group to the datapackage.
+
+        ``scale_array`` is an optional 1-D float array of the same length as
+        ``indices_array``.  Each element is a multiplicative factor applied to
+        the corresponding data value — whether static or stochastic — before
+        the value is inserted into the matrix.  Typical uses are allocation
+        factors and unit conversions.  A value of ``1.0`` leaves the data
+        unchanged.
+        """
         self._prepare_modifications()
 
         kwargs.update({"matrix": matrix, "category": "array", "nrows": len(indices_array)})
@@ -660,6 +687,15 @@ class Datapackage(DatapackageBase):
                     meta_type="generic",
                     **kwargs,
                 )
+        if scale_array is not None:
+            self._add_scale_array_resource(
+                scale_array=scale_array,
+                indices_array=indices_array,
+                name=name,
+                keep_proxy=keep_proxy,
+                matrix_serialize_format_type=matrix_serialize_format_type,
+                **kwargs,
+            )
 
     def write_modified(self):
         """Write the data in modified files to the filesystem (if allowed)."""
@@ -683,7 +719,7 @@ class Datapackage(DatapackageBase):
                     if kind == "indices":
                         meta_object = "vector"
                         meta_type = "indices"
-                    elif kind == "flip":
+                    elif kind in ("flip", "scale"):
                         meta_object = "vector"
                         meta_type = "generic"
                     elif kind == "distributions":
@@ -715,6 +751,39 @@ class Datapackage(DatapackageBase):
             )
 
         self._modified = set()
+
+    def _add_scale_array_resource(
+        self,
+        *,
+        scale_array: np.ndarray,
+        indices_array: np.ndarray,
+        name: str,
+        keep_proxy: bool,
+        matrix_serialize_format_type: Optional[MatrixSerializeFormat],
+        **kwargs,
+    ) -> None:
+        scale_array = load_bytes(scale_array)
+        if not np.issubdtype(scale_array.dtype, np.floating):
+            raise WrongDatatype(
+                "`scale_array` dtype is {}, but must be a float dtype".format(scale_array.dtype)
+            )
+        elif scale_array.shape != indices_array.shape:
+            raise ShapeMismatch(
+                "`scale_array` shape ({}) doesn't match `indices_array` ({}).".format(
+                    scale_array.shape, indices_array.shape
+                )
+            )
+        self._add_numpy_array_resource(
+            array=scale_array,
+            group=name,
+            name=name + ".scale",
+            kind="scale",
+            keep_proxy=keep_proxy,
+            matrix_serialize_format_type=matrix_serialize_format_type,
+            meta_object="vector",
+            meta_type="generic",
+            **kwargs,
+        )
 
     def _add_numpy_array_resource(
         self,
@@ -798,6 +867,7 @@ class Datapackage(DatapackageBase):
         indices_array: np.ndarray,  # Not interface
         name: Optional[str] = None,
         flip_array: Optional[np.ndarray] = None,  # Not interface
+        scale_array: Optional[np.ndarray] = None,  # Not interface
         keep_proxy: bool = False,
         matrix_serialize_format_type: Optional[MatrixSerializeFormat] = None,
         **kwargs,
@@ -843,6 +913,15 @@ class Datapackage(DatapackageBase):
                     meta_type="generic",
                     **kwargs,
                 )
+        if scale_array is not None:
+            self._add_scale_array_resource(
+                scale_array=scale_array,
+                indices_array=indices_array,
+                name=name,
+                keep_proxy=keep_proxy,
+                matrix_serialize_format_type=matrix_serialize_format_type,
+                **kwargs,
+            )
 
         self.data.append(interface)
         resource = {
@@ -862,6 +941,7 @@ class Datapackage(DatapackageBase):
         indices_array: np.ndarray,  # Not interface
         name: Optional[str] = None,
         flip_array: Optional[np.ndarray] = None,
+        scale_array: Optional[np.ndarray] = None,  # Not interface
         keep_proxy: bool = False,
         matrix_serialize_format_type: Optional[MatrixSerializeFormat] = None,
         **kwargs,
@@ -911,6 +991,15 @@ class Datapackage(DatapackageBase):
                     meta_type="generic",
                     **kwargs,
                 )
+        if scale_array is not None:
+            self._add_scale_array_resource(
+                scale_array=scale_array,
+                indices_array=indices_array,
+                name=name,
+                keep_proxy=keep_proxy,
+                matrix_serialize_format_type=matrix_serialize_format_type,
+                **kwargs,
+            )
 
         self.data.append(interface)
         resource = {

--- a/tests/test_datapackage.py
+++ b/tests/test_datapackage.py
@@ -457,6 +457,192 @@ def test_add_dynamic_vector_flip_shapemistmatch():
         )
 
 
+def test_add_persistent_vector_scale_array():
+    dp = create_datapackage()
+    data_array = np.array([2.0, 7.0, 12.0])
+    scale_array = np.array([0.5, 1.0, 2.0])
+    indices_array = np.array([(1, 4), (2, 5), (3, 6)], dtype=INDICES_DTYPE)
+    dp.add_persistent_vector(
+        matrix="sa_matrix",
+        data_array=data_array,
+        name="sa-data-vector",
+        indices_array=indices_array,
+        scale_array=scale_array,
+    )
+    assert "sa-data-vector.scale" in [o["name"] for o in dp.resources]
+    data, meta = dp.get_resource("sa-data-vector.scale")
+    assert meta["kind"] == "scale"
+    assert np.allclose(data, scale_array)
+
+
+def test_add_persistent_vector_scale_dtype():
+    dp = create_datapackage()
+    data_array = np.array([2.0, 7.0, 12.0])
+    scale_array = np.array([1, 2, 3])  # integer dtype
+    indices_array = np.array([(1, 4), (2, 5), (3, 6)], dtype=INDICES_DTYPE)
+    with pytest.raises(WrongDatatype):
+        dp.add_persistent_vector(
+            matrix="sa_matrix",
+            data_array=data_array,
+            name="sa-data-vector",
+            indices_array=indices_array,
+            scale_array=scale_array,
+        )
+
+
+def test_add_persistent_vector_scale_shapemismatch():
+    dp = create_datapackage()
+    data_array = np.array([2.0, 7.0, 12.0])
+    scale_array = np.array([0.5, 1.0, 2.0, 3.0])
+    indices_array = np.array([(1, 4), (2, 5), (3, 6)], dtype=INDICES_DTYPE)
+    with pytest.raises(ShapeMismatch):
+        dp.add_persistent_vector(
+            matrix="sa_matrix",
+            data_array=data_array,
+            name="sa-data-vector",
+            indices_array=indices_array,
+            scale_array=scale_array,
+        )
+
+
+def test_add_persistent_array_scale_array():
+    dp = create_datapackage()
+    data_array = np.arange(12, dtype=float).reshape(3, 4)
+    scale_array = np.array([0.5, 1.0, 2.0])
+    indices_array = np.array([(1, 4), (2, 5), (3, 6)], dtype=INDICES_DTYPE)
+    dp.add_persistent_array(
+        matrix="sa_matrix",
+        data_array=data_array,
+        name="sa-data-vector",
+        indices_array=indices_array,
+        scale_array=scale_array,
+    )
+    assert "sa-data-vector.scale" in [o["name"] for o in dp.resources]
+    data, meta = dp.get_resource("sa-data-vector.scale")
+    assert meta["kind"] == "scale"
+    assert np.allclose(data, scale_array)
+
+
+def test_add_persistent_array_scale_dtype():
+    dp = create_datapackage()
+    data_array = np.arange(12, dtype=float).reshape(3, 4)
+    scale_array = np.array([1, 2, 3])
+    indices_array = np.array([(1, 4), (2, 5), (3, 6)], dtype=INDICES_DTYPE)
+    with pytest.raises(WrongDatatype):
+        dp.add_persistent_array(
+            matrix="sa_matrix",
+            data_array=data_array,
+            name="sa-data-vector",
+            indices_array=indices_array,
+            scale_array=scale_array,
+        )
+
+
+def test_add_persistent_array_scale_shapemismatch():
+    dp = create_datapackage()
+    data_array = np.arange(12, dtype=float).reshape(3, 4)
+    scale_array = np.array([0.5, 1.0, 2.0, 3.0])
+    indices_array = np.array([(1, 4), (2, 5), (3, 6)], dtype=INDICES_DTYPE)
+    with pytest.raises(ShapeMismatch):
+        dp.add_persistent_array(
+            matrix="sa_matrix",
+            data_array=data_array,
+            name="sa-data-vector",
+            indices_array=indices_array,
+            scale_array=scale_array,
+        )
+
+
+def test_add_dynamic_vector_scale_array():
+    dp = create_datapackage()
+    scale_array = np.array([0.5, 1.0, 2.0])
+    indices_array = np.array([(1, 4), (2, 5), (3, 6)], dtype=INDICES_DTYPE)
+    dp.add_dynamic_vector(
+        matrix="sa_matrix",
+        interface=Dummy(),
+        name="sa-data-vector",
+        indices_array=indices_array,
+        scale_array=scale_array,
+    )
+    assert "sa-data-vector.scale" in [o["name"] for o in dp.resources]
+    data, meta = dp.get_resource("sa-data-vector.scale")
+    assert meta["kind"] == "scale"
+    assert np.allclose(data, scale_array)
+
+
+def test_add_dynamic_vector_scale_dtype():
+    dp = create_datapackage()
+    scale_array = np.array([1, 2, 3])
+    indices_array = np.array([(1, 4), (2, 5), (3, 6)], dtype=INDICES_DTYPE)
+    with pytest.raises(WrongDatatype):
+        dp.add_dynamic_vector(
+            matrix="sa_matrix",
+            interface=Dummy(),
+            name="sa-data-vector",
+            indices_array=indices_array,
+            scale_array=scale_array,
+        )
+
+
+def test_add_dynamic_vector_scale_shapemismatch():
+    dp = create_datapackage()
+    scale_array = np.array([0.5, 1.0, 2.0, 3.0])
+    indices_array = np.array([(1, 4), (2, 5), (3, 6)], dtype=INDICES_DTYPE)
+    with pytest.raises(ShapeMismatch):
+        dp.add_dynamic_vector(
+            matrix="sa_matrix",
+            interface=Dummy(),
+            name="sa-data-vector",
+            indices_array=indices_array,
+            scale_array=scale_array,
+        )
+
+
+def test_add_dynamic_array_scale_array():
+    dp = create_datapackage()
+    scale_array = np.array([0.5, 1.0, 2.0])
+    indices_array = np.array([(1, 4), (2, 5), (3, 6)], dtype=INDICES_DTYPE)
+    dp.add_dynamic_array(
+        matrix="sa_matrix",
+        interface=Dummy(),
+        name="sa-data-vector",
+        indices_array=indices_array,
+        scale_array=scale_array,
+    )
+    assert "sa-data-vector.scale" in [o["name"] for o in dp.resources]
+    data, meta = dp.get_resource("sa-data-vector.scale")
+    assert meta["kind"] == "scale"
+    assert np.allclose(data, scale_array)
+
+
+def test_add_dynamic_array_scale_dtype():
+    dp = create_datapackage()
+    scale_array = np.array([1, 2, 3])
+    indices_array = np.array([(1, 4), (2, 5), (3, 6)], dtype=INDICES_DTYPE)
+    with pytest.raises(WrongDatatype):
+        dp.add_dynamic_array(
+            matrix="sa_matrix",
+            interface=Dummy(),
+            name="sa-data-vector",
+            indices_array=indices_array,
+            scale_array=scale_array,
+        )
+
+
+def test_add_dynamic_array_scale_shapemismatch():
+    dp = create_datapackage()
+    scale_array = np.array([0.5, 1.0, 2.0, 3.0])
+    indices_array = np.array([(1, 4), (2, 5), (3, 6)], dtype=INDICES_DTYPE)
+    with pytest.raises(ShapeMismatch):
+        dp.add_dynamic_array(
+            matrix="sa_matrix",
+            interface=Dummy(),
+            name="sa-data-vector",
+            indices_array=indices_array,
+            scale_array=scale_array,
+        )
+
+
 def test_simple_graph():
     data = {
         "some_matrix": [(1, 2, 3.14), (4, 5, 17, True), (8, 9, 11.11, False)],

--- a/tests/test_datapackage.py
+++ b/tests/test_datapackage.py
@@ -8,7 +8,7 @@ import pytest
 from fsspec.implementations.zip import ZipFileSystem
 from morefs.dict import DictFS
 
-from bw_processing import create_datapackage, load_datapackage, simple_graph
+from bw_processing import create_datapackage, load_datapackage, simple_graph, MatrixSerializeFormat
 from bw_processing.constants import INDICES_DTYPE, UNCERTAINTY_DTYPE, MAX_SIGNED_64BIT_INT, MAX_SIGNED_32BIT_INT
 from bw_processing.errors import NonUnique, PotentialInconsistency, ShapeMismatch, WrongDatatype
 from bw_processing.io_helpers import generic_directory_filesystem, generic_zipfile_filesystem
@@ -641,6 +641,32 @@ def test_add_dynamic_array_scale_shapemismatch():
             indices_array=indices_array,
             scale_array=scale_array,
         )
+
+
+def test_scale_array_parquet_roundtrip(tmp_path):
+    scale_array = np.array([0.5, 1.0, 2.0])
+    indices_array = np.array([(1, 4), (2, 5), (3, 6)], dtype=INDICES_DTYPE)
+    data_array = np.array([100.0, 200.0, 300.0])
+
+    dp = create_datapackage(
+        fs=generic_directory_filesystem(dirpath=tmp_path),
+        name="scale-parquet-test",
+    )
+    dp.add_persistent_vector(
+        matrix="sa_matrix",
+        data_array=data_array,
+        name="sa-data-vector",
+        indices_array=indices_array,
+        scale_array=scale_array,
+        matrix_serialize_format_type=MatrixSerializeFormat.PARQUET,
+    )
+    dp.finalize_serialization()
+
+    dp2 = load_datapackage(generic_directory_filesystem(dirpath=tmp_path))
+    assert "sa-data-vector.scale" in [o["name"] for o in dp2.resources]
+    loaded, meta = dp2.get_resource("sa-data-vector.scale")
+    assert meta["kind"] == "scale"
+    assert np.allclose(loaded, scale_array)
 
 
 def test_simple_graph():


### PR DESCRIPTION
## Summary

- Adds an optional `scale_array` parameter (1-D float, same length as `indices_array`) to all four `add_*` methods: `add_persistent_vector`, `add_persistent_array`, `add_dynamic_vector`, and `add_dynamic_array`
- Stored resources use `kind="scale"` and act as per-exchange multiplicative factors applied to data values — both static and stochastic — before matrix insertion
- Typical uses: allocation factors and unit conversions in life cycle assessment
- Validation and storage are centralised in a new `_add_scale_array_resource` private helper to avoid duplication across the four methods
- `write_modified` updated to handle `"scale"` kind under Parquet serialisation
- README updated with a background bullet and a new `Scale arrays` Concepts subsection with a worked example

## Test plan

- [ ] 4 happy-path tests (one per `add_*` method): verify resource is stored with `kind="scale"` and correct values
- [ ] 4 dtype-rejection tests: integer `scale_array` raises `WrongDatatype`
- [ ] 4 shape-mismatch tests: wrong-length `scale_array` raises `ShapeMismatch`
- [ ] All 166 tests pass (`154` pre-existing + `12` new), `1` skipped