### PR TITLE
Improve docstrings and fill out README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,18 @@ Data objects can be vectors or arrays. Vectors will always produce the same matr
 
 ### Vectors versus arrays
 
+Vectors and arrays differ in how many possible values they provide per matrix cell.
+
+A **vector** provides one value per cell. Every time a vector resource is used, it produces the same result. This is the standard case for deterministic LCA calculations.
+
+An **array** provides multiple possible values per cell, stored as columns of a 2-D numpy array. Each time the data package is iterated, a different column is selected and inserted into the matrix. This is used for:
+
+* **Monte Carlo analysis** — columns hold independently sampled values drawn from the uncertainty distributions.
+* **Scenario analysis** — each column represents a predefined scenario, such as a different technology mix or policy assumption.
+* **Presamples** — a generalization of the [presamples library](https://github.com/PascalLesage/presamples/), where pre-drawn samples are stored for reproducibility.
+
+Which column is selected on each iteration is controlled by the `sequential` and `combinatorial` policies; see [Policies](#policies).
+
 ### Persistent versus dynamic
 
 Persistent data is fixed, and can be completely loaded into memory and used directly or written to disk. Dynamic data is only resolved as the data is used, during matrix construction and iteration. Dynamic data is provided by *interfaces* - Python code that either generates the data, or wraps data coming from other software. There are many possible use cases for data interfaces, including:
@@ -208,7 +220,7 @@ Please make sure you understand how `combinatorial` and `sequential` interact! T
 
 ## Install
 
-Install using pip or conda (channel `cmutel`). Depends on `numpy` and `pandas` (for reading and writing CSVs).
+Install using pip or conda (channel `conda-forge`). Depends on `numpy` and `pandas` (for reading and writing CSVs).
 
 Has no explicit or implicit dependence on any other part of Brightway.
 

--- a/src/bw_processing/constants.py
+++ b/src/bw_processing/constants.py
@@ -35,12 +35,15 @@ DEFAULT_LICENSES = [
 
 
 class MatrixSerializeFormat(str, Enum):
-    """
-    Enum with the serializing formats for the vectors and matrices.
+    """Serialization format used when writing numpy arrays to disk.
+
+    Because this is a ``str`` enum, values can be compared directly to strings.
+    The default is ``NUMPY``.  ``PARQUET`` requires the optional ``pyarrow``
+    dependency.
     """
 
-    NUMPY = "numpy"  # numpy .npy format
-    PARQUET = "parquet"  # Apache .parquet format
+    NUMPY = "numpy"
+    PARQUET = "parquet"
 
 
 # FILE EXTENSIONS

--- a/src/bw_processing/datapackage.py
+++ b/src/bw_processing/datapackage.py
@@ -384,6 +384,17 @@ class Datapackage(DatapackageBase):
         self.data = []
 
     def finalize_serialization(self) -> None:
+        """Write the metadata file and close the filesystem.
+
+        Must be called once after all resources have been added, before the
+        datapackage can be loaded again from disk. Dehydrates any interface
+        resources (replaces them with ``UndefinedInterface``) prior to writing.
+
+        Raises:
+            Closed: Datapackage has already been finalized.
+            ValueError: Datapackage uses an in-memory filesystem, which cannot
+                be serialized.
+        """
         if self._finalized:
             raise Closed("Datapackage already finalized")
         elif isinstance(self.fs, DictFS):
@@ -698,7 +709,12 @@ class Datapackage(DatapackageBase):
             )
 
     def write_modified(self):
-        """Write the data in modified files to the filesystem (if allowed)."""
+        """Flush modified resources back to the filesystem.
+
+        After directly editing data arrays in ``self.data``, call this method
+        to persist the changes. Clears the internal ``_modified`` set on
+        completion. Does nothing if no resources have been marked as modified.
+        """
         for index in self._modified:
             # get resource
             resource = self.resources[index]
@@ -872,6 +888,31 @@ class Datapackage(DatapackageBase):
         matrix_serialize_format_type: Optional[MatrixSerializeFormat] = None,
         **kwargs,
     ) -> None:
+        """Add a dynamic vector resource group to the datapackage.
+
+        The matrix values are provided at runtime by ``interface`` rather than
+        stored on disk. ``interface`` must implement ``__next__()`` and return a
+        1-D numpy array of length ``len(indices_array)`` each time it is called.
+
+        The ``indices_array``, optional ``flip_array``, and optional
+        ``scale_array`` are static and are stored as normal numpy resources.
+
+        Args:
+            matrix: Name of the target matrix.
+            interface: Object implementing the dynamic-vector interface
+                (``__next__()``).
+            indices_array: Structured numpy array with dtype ``INDICES_DTYPE``
+                mapping each data value to a matrix cell.
+            name: Optional resource group name; auto-generated if omitted.
+            flip_array: Optional boolean array; where ``True`` the value is
+                multiplied by ``-1`` before insertion.
+            scale_array: Optional 1-D float array of multiplicative factors
+                applied before matrix insertion.
+            keep_proxy: If ``True``, store a proxy rather than the raw array
+                for on-disk resources.
+            matrix_serialize_format_type: Override the instance-level
+                serialization format for static arrays in this group.
+        """
         self._prepare_modifications()
 
         kwargs.update({"matrix": matrix, "category": "vector", "nrows": len(indices_array)})
@@ -946,7 +987,33 @@ class Datapackage(DatapackageBase):
         matrix_serialize_format_type: Optional[MatrixSerializeFormat] = None,
         **kwargs,
     ) -> None:
-        """`interface` must support the presamples API."""
+        """Add a dynamic array resource group to the datapackage.
+
+        The matrix values are provided at runtime by ``interface``, which must
+        implement the presamples array API: a ``.shape`` property returning
+        ``(nrows, ncols)`` and ``.__getitem__(args)`` returning the 1-D column
+        array for ``args[1]``.  ``ncols`` may be ``None`` for an infinite
+        interface.
+
+        The ``indices_array``, optional ``flip_array``, and optional
+        ``scale_array`` are static and are stored as normal numpy resources.
+
+        Args:
+            matrix: Name of the target matrix.
+            interface: Object implementing the dynamic-array interface
+                (``.shape`` and ``.__getitem__``).
+            indices_array: Structured numpy array with dtype ``INDICES_DTYPE``
+                mapping each data value to a matrix cell.
+            name: Optional resource group name; auto-generated if omitted.
+            flip_array: Optional boolean array; where ``True`` the value is
+                multiplied by ``-1`` before insertion.
+            scale_array: Optional 1-D float array of multiplicative factors
+                applied before matrix insertion.
+            keep_proxy: If ``True``, store a proxy rather than the raw array
+                for on-disk resources.
+            matrix_serialize_format_type: Override the instance-level
+                serialization format for static arrays in this group.
+        """
         self._prepare_modifications()
 
         if isinstance(flip_array, np.ndarray) and not flip_array.sum():

--- a/src/bw_processing/io_helpers.py
+++ b/src/bw_processing/io_helpers.py
@@ -27,6 +27,19 @@ except ImportError:
 
 
 def generic_directory_filesystem(*, dirpath: Path) -> DirFileSystem:
+    """Return a ``DirFileSystem`` rooted at ``dirpath``, creating it if needed.
+
+    Args:
+        dirpath: Path to the target directory. Created if it does not exist;
+            its parent must already exist.
+
+    Returns:
+        A ``fsspec`` ``DirFileSystem`` pointing at ``dirpath``.
+
+    Raises:
+        ValueError: Parent directory does not exist.
+        AssertionError: ``dirpath`` is not a ``pathlib.Path``.
+    """
     assert isinstance(dirpath, Path), "`dirpath` must be a `pathlib.Path` instance"
     if not dirpath.is_dir():
         if not dirpath.parent.is_dir():
@@ -43,6 +56,28 @@ def generic_zipfile_filesystem(
     compression: int = zipfile.ZIP_DEFLATED,
     compresslevel: Optional[int] = None,
 ) -> ZipFileSystem:
+    """Return a ``ZipFileSystem`` for ``dirpath / filename``.
+
+    Args:
+        dirpath: Directory that contains (or will contain) the zip file.
+            Must already exist.
+        filename: Name of the zip file (e.g. ``"my-dp.zip"``).
+        write: If ``True`` (default), open for writing; otherwise open for
+            reading.
+        compression: ``zipfile`` compression constant.  Defaults to
+            ``zipfile.ZIP_DEFLATED`` which gives good compression speed.
+            Pass ``zipfile.ZIP_STORED`` for no compression or
+            ``zipfile.ZIP_LZMA`` for maximum compression.
+        compresslevel: Compression level passed to ``zipfile.ZipFile``;
+            ``None`` uses the default for the chosen algorithm.
+
+    Returns:
+        A ``fsspec`` ``ZipFileSystem``.
+
+    Raises:
+        ValueError: ``dirpath`` does not exist.
+        AssertionError: ``dirpath`` is not a ``pathlib.Path``.
+    """
     assert isinstance(dirpath, Path), "`dirpath` must be a `pathlib.Path` instance"
     if not dirpath.is_dir():
         raise ValueError("Destination directory `{}` doesn't exist".format(dirpath))

--- a/src/bw_processing/proxies.py
+++ b/src/bw_processing/proxies.py
@@ -5,6 +5,14 @@ class UndefinedInterface:
 
 
 class Proxy:
+    """Deferred file-read wrapper returned when ``proxy=True`` is passed to ``file_reader``.
+
+    Stores the reader function and its arguments without executing them. The
+    actual data is loaded the first time the proxy is called (i.e. when
+    ``get_resource`` resolves it). The file or buffer is rewound to position 0
+    before each call so that repeated calls return the same data.
+    """
+
     def __init__(self, func, label, kwargs):
         self.func = func
         self.label = label

--- a/src/bw_processing/unique_fields.py
+++ b/src/bw_processing/unique_fields.py
@@ -60,6 +60,23 @@ def greedy_set_cover(data, exclude=None, raise_error=True):
 
 
 def as_unique_attributes_dataframe(df, exclude=None, include=None, raise_error=False):
+    """Return a copy of ``df`` keeping only the columns needed to uniquely identify each row.
+
+    Columns are selected using the greedy set-cover heuristic (see
+    :func:`greedy_set_cover`). Columns listed in ``include`` are always kept,
+    even if they are not required for uniqueness.
+
+    Args:
+        df: Input pandas DataFrame.
+        exclude: Column names to skip during the uniqueness search.
+        include: Column names to always retain in the output.
+        raise_error: If ``True``, raise ``NonUnique`` when no unique set can be
+            found; otherwise, all columns are kept silently.
+
+    Returns:
+        A DataFrame with only the uniqueness-covering (and always-included)
+        columns.
+    """
     assert isinstance(df, pd.DataFrame)
     include = greedy_set_cover(
         df.reset_index().to_dict("records"), exclude=exclude, raise_error=raise_error


### PR DESCRIPTION
## Summary

- Fills in the empty **Vectors versus arrays** README section with prose matching the surrounding style
- Updates the conda install channel from `cmutel` to `conda-forge`
- Adds or improves docstrings on several public API methods that were missing them: `finalize_serialization`, `write_modified`, `add_dynamic_vector`, `add_dynamic_array`, `generic_directory_filesystem`, `generic_zipfile_filesystem`, `Proxy`, `as_unique_attributes_dataframe`, and `MatrixSerializeFormat`

## Test plan

- [ ] Confirm README renders correctly on GitHub
- [ ] Existing test suite passes (`pytest`)