### PR TITLE
Bump version to 1.3 and update changelog

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # `bw_processing` Changelog
 
+## [1.3] - 2026-06-02
+
+* [PR #90: Improve docstrings and fill out README; update conda channel to `conda-forge`](https://github.com/brightway-lca/bw_processing/pull/90)
+
 ## [1.2] - 2026-05-26
 
 * [PR #87: Default to `ZIP_DEFLATED` compression in `generic_zipfile_filesystem`; index arrays compress to ~10% of original size, reducing large datapackages ~4×](https://github.com/brightway-lca/bw_processing/pull/87)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## [1.3] - 2026-06-02
 
+* [PR #89: Add `scale_array` support for per-exchange multiplicative rescaling](https://github.com/brightway-lca/bw_processing/pull/89)
 * [PR #90: Improve docstrings and fill out README; update conda channel to `conda-forge`](https://github.com/brightway-lca/bw_processing/pull/90)
 
 ## [1.2] - 2026-05-26

--- a/src/bw_processing/__init__.py
+++ b/src/bw_processing/__init__.py
@@ -29,7 +29,7 @@ __all__ = (
     "UndefinedInterface",
 )
 
-__version__ = "1.2"
+__version__ = "1.3"
 
 
 from bw_processing.array_creation import create_array, create_structured_array


### PR DESCRIPTION
## Summary

- Bumps version to 1.3
- Adds changelog entries for PRs merged since 1.2:
  - #89: `scale_array` support for per-exchange multiplicative rescaling
  - #90: Improved docstrings and README; conda channel updated to `conda-forge`