### PR TITLE
Add params_array support for sensitivity analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,11 @@ schema = ParamLabelSchema(
     description="Brightway activity reference",
 )
 
+param_labels = [
+    {"name": "electricity", "database": "ecoinvent", "year": 2020},
+    {"name": "heat",        "database": "ecoinvent"},
+]
+
 dp.add_persistent_array(
     matrix="technosphere",
     name="sa-run",
@@ -282,10 +287,7 @@ dp.add_persistent_array(
                          [40.0, 50.0, 60.0]]),
     params_array=np.array([[25.0, 30.0, 35.0],  # temperature: 2 params × 3 scenarios
                             [1.0,  1.1,  1.2]]),
-    param_labels=[
-        {"name": "electricity", "database": "ecoinvent", "year": 2020},
-        {"name": "heat",        "database": "ecoinvent"},
-    ],
+    param_labels=param_labels,
     param_label_schema=schema,  # validates every label against the JSON Schema on write
 )
 ```

--- a/README.md
+++ b/README.md
@@ -260,7 +260,6 @@ from bw_processing import (
     INDICES_DTYPE,
     ParamLabelField,
     ParamLabelSchema,
-    StringLabelSchema,
 )
 
 dp = create_datapackage()

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ dp.add_persistent_vector(
 
 #### Adding labels
 
-`param_labels` is an optional list of label objects (strings or dicts) whose length must match `params_array.shape[0]`. When provided, a companion `name.param_labels.json` file is written inside the same resource group, containing a `"values"` list and an optional `"schema"` (a [JSON Schema](https://json-schema.org/) document).
+`param_labels` is an optional list of label objects (strings or dicts) whose length must match `params_array.shape[0]`. When provided, a companion `name.param_labels.json` file is written inside the same resource group, containing a `"values"` list and an optional `"schema"` (a [JSON Schema](https://json-schema.org/) document). Pass `param_label_schema=StringLabelSchema()` for plain-string labels, or a `ParamLabelSchema` for structured dict labels.
 
 ```python
 import numpy as np
@@ -244,7 +244,8 @@ dp.add_persistent_vector(
     indices_array=np.array([(1, 4)], dtype=INDICES_DTYPE),
     data_array=np.array([100.0]),
     params_array=np.array([25.0, 1.013]),
-    param_labels=["temperature", "pressure"],  # plain strings — no schema needed
+    param_labels=["temperature", "pressure"],
+    param_label_schema=StringLabelSchema(),
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,13 @@ Library for storing numeric data for use in matrix-based calculations. Designed 
 
 - [Background](#background)
 - [Concepts](#concepts)
+  - [Data packages](#data-packages)
+  - [Vectors versus arrays](#vectors-versus-arrays)
+  - [Persistent versus dynamic](#persistent-versus-dynamic)
+  - [Scale arrays](#scale-arrays)
+  - [Parameter arrays for sensitivity analysis](#parameter-arrays-for-sensitivity-analysis)
+  - [NaN as a sentinel value](#nan-as-a-sentinel-value)
+  - [Policies](#policies)
 - [Install](#install)
 - [Usage](#usage)
 - [Contributing](#contributing)
@@ -43,6 +50,7 @@ The [Brightway LCA framework](https://brightway.dev/) has stored data used in co
 * **Use [fsspec](https://filesystem-spec.readthedocs.io/en/latest/) for file IO**. The use of this library allows for data packages to be stored on your local computer, or on [many logical or virtual file systems](https://docs.pyfilesystem.org/en/latest/guide.html).
 * **Simpler handling of numeric values whose sign should be flipped**. Sometimes it is more convenient to specify positive numbers in dataset definitions, even though such numbers should be negative when inserted into the resulting matrices. For example, in the technosphere matrix in life cycle assessment, products produced are positive and products consumed are negative, though both values are given as positive in datasets. Brightway used to use a type mapping dictionary to indicate which values in a matrix should have their sign flipped after insertion. Such mapping dictionaries are brittle and inelegant. `bw_processing` uses an optional boolean vector, called `flip`, to indicate if any values should be flipped.
 * **Per-exchange multiplicative scaling**. An optional float vector, called `scale`, can be attached to any resource group. Each element is a multiplicative factor applied to the corresponding data value — whether static or sampled stochastically — before it is inserted into the matrix. Typical uses are allocation factors and unit conversions. A value of `1.0` leaves the data unchanged.
+* **Recording independent variables for sensitivity analysis**. An optional `params_array` can be attached to any resource group to record the values of model parameters (independent variables) that were used to generate the data. For array resources each column of `params_array` corresponds to the same column in `data_array`, making it straightforward to correlate inputs with outputs for sensitivity analysis methods such as Morris or Sobol.
 * **Separation of uncertainty distribution parameters from other data**. Fitting data to a [probability density function](https://en.wikipedia.org/wiki/Probability_density_function) (PDF), or an estimate of such a PDF, is only one approach to quantitative uncertainty analysis. We would like to support other approaches, including [direct sampling from real data](https://github.com/PascalLesage/presamples/). Therefore, uncertainty distribution parameters are stored separately,  only loaded if needed, and are only one way to express quantitative uncertainty.
 
 ## Concepts
@@ -187,6 +195,117 @@ dp.add_persistent_vector(
 ```
 
 The stored resource has `kind="scale"` and can be retrieved via `dp.get_resource("my-process.scale")`. The `scale_array` must be a float dtype (`float32` or `float64`); passing an integer array raises `WrongDatatype`.
+
+### Parameter arrays for sensitivity analysis
+
+Any resource group can carry an optional `params_array` that records the values of the independent variables (model parameters) used to generate the data. This is the foundation for global sensitivity analysis workflows such as [Morris screening](https://en.wikipedia.org/wiki/Morris_method) or [Sobol indices](https://en.wikipedia.org/wiki/Variance-based_sensitivity_analysis).
+
+**Shape conventions:**
+
+| Resource type | `data_array` shape | `params_array` shape |
+|---|---|---|
+| persistent / dynamic vector | `(n_exchanges,)` | `(n_params,)` |
+| persistent array | `(n_exchanges, n_scenarios)` | `(n_params, n_scenarios)` |
+| dynamic array | `(n_exchanges, n_scenarios)` | `(n_params, n_scenarios)` — column count not validated against interface |
+
+Column `j` of `params_array` describes the parameter configuration that produced column `j` of `data_array`. The `params_array` must be a float dtype.
+
+#### Basic usage
+
+```python
+import numpy as np
+from bw_processing import create_datapackage, INDICES_DTYPE
+
+dp = create_datapackage()
+indices = np.array([(1, 4), (2, 5)], dtype=INDICES_DTYPE)
+
+# Store the parameter values alongside the data
+dp.add_persistent_vector(
+    matrix="technosphere",
+    name="my-process",
+    indices_array=indices,
+    data_array=np.array([100.0, 200.0]),
+    params_array=np.array([25.0, 1.013]),  # temperature (°C), pressure (atm)
+)
+```
+
+#### Adding labels
+
+`param_labels` is an optional list of label objects (strings or dicts) whose length must match `params_array.shape[0]`. When provided, a companion `name.param_labels.json` file is written inside the same resource group, containing a `"values"` list and an optional `"schema"` (a [JSON Schema](https://json-schema.org/) document).
+
+```python
+import numpy as np
+from bw_processing import create_datapackage, INDICES_DTYPE, StringLabelSchema
+
+dp = create_datapackage()
+dp.add_persistent_vector(
+    matrix="technosphere",
+    name="my-process",
+    indices_array=np.array([(1, 4)], dtype=INDICES_DTYPE),
+    data_array=np.array([100.0]),
+    params_array=np.array([25.0, 1.013]),
+    param_labels=["temperature", "pressure"],  # plain strings — no schema needed
+)
+```
+
+#### Structured labels with a schema
+
+Use `ParamLabelSchema` and `ParamLabelField` when labels are structured objects, and pass a `param_label_schema` to validate each label at write time:
+
+```python
+import numpy as np
+from bw_processing import (
+    create_datapackage,
+    INDICES_DTYPE,
+    ParamLabelField,
+    ParamLabelSchema,
+    StringLabelSchema,
+)
+
+dp = create_datapackage()
+
+schema = ParamLabelSchema(
+    fields=[
+        ParamLabelField(name="name",      type="string"),
+        ParamLabelField(name="database",  type="string"),
+        ParamLabelField(name="amount",    type="number", required=False),
+    ],
+    description="Brightway activity reference",
+)
+
+dp.add_persistent_array(
+    matrix="technosphere",
+    name="sa-run",
+    indices_array=np.array([(1, 4), (2, 5)], dtype=INDICES_DTYPE),
+    data_array=np.array([[10.0, 20.0, 30.0],   # 2 exchanges × 3 scenarios
+                         [40.0, 50.0, 60.0]]),
+    params_array=np.array([[25.0, 30.0, 35.0],  # temperature: 2 params × 3 scenarios
+                            [1.0,  1.1,  1.2]]),
+    param_labels=[
+        {"name": "electricity", "database": "ecoinvent", "amount": 1.0},
+        {"name": "heat",        "database": "ecoinvent"},
+    ],
+    param_label_schema=schema,  # validates every label against the JSON Schema on write
+)
+```
+
+`ParamLabelField.type` accepts the standard JSON Schema type names: `"string"`, `"integer"`, `"number"`, `"boolean"`. For plain-string labels you can also pass `param_label_schema=StringLabelSchema()` to make the schema explicit.
+
+#### Retrieving params and labels
+
+```python
+params_data, _  = dp.get_resource("sa-run.params")       # numpy array
+labels_data, _  = dp.get_resource("sa-run.param_labels")  # {"schema": ..., "values": [...]}
+
+# Reconstruct the schema dataclass from the stored JSON Schema:
+from bw_processing import schema_from_json_schema
+schema = schema_from_json_schema(labels_data["schema"])
+# → ParamLabelSchema(fields=[...])
+```
+
+#### Dependency
+
+`params_array` validation uses the [`jsonschema`](https://python-jsonschema.readthedocs.io/) library, which is a required dependency of `bw_processing`.
 
 ### NaN as a sentinel value
 

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ schema = ParamLabelSchema(
     fields=[
         ParamLabelField(name="name",      type="string"),
         ParamLabelField(name="database",  type="string"),
-        ParamLabelField(name="amount",    type="number", required=False),
+        ParamLabelField(name="year",      type="integer", required=False),
     ],
     description="Brightway activity reference",
 )
@@ -282,7 +282,7 @@ dp.add_persistent_array(
     params_array=np.array([[25.0, 30.0, 35.0],  # temperature: 2 params × 3 scenarios
                             [1.0,  1.1,  1.2]]),
     param_labels=[
-        {"name": "electricity", "database": "ecoinvent", "amount": 1.0},
+        {"name": "electricity", "database": "ecoinvent", "year": 2020},
         {"name": "heat",        "database": "ecoinvent"},
     ],
     param_label_schema=schema,  # validates every label against the JSON Schema on write

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     # dependencies as strings with quotes, e.g. "foo"
     # You can add version requirements
     "fsspec",
-    "jsonschema",
+    "jsonschema>=4.0",
     "morefs",
     "numpy",
     "pandas",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     # dependencies as strings with quotes, e.g. "foo"
     # You can add version requirements
     "fsspec",
+    "jsonschema",
     "morefs",
     "numpy",
     "pandas",

--- a/src/bw_processing/__init__.py
+++ b/src/bw_processing/__init__.py
@@ -1,5 +1,6 @@
 __all__ = (
     "__version__",
+    "AnyLabelSchema",
     "as_unique_attributes",
     "as_unique_attributes_dataframe",
     "clean_datapackage_name",
@@ -21,10 +22,14 @@ __all__ = (
     "MatrixSerializeFormat",
     "md5",
     "merge_datapackages_with_mask",
+    "ParamLabelField",
+    "ParamLabelSchema",
     "reindex",
     "reset_index",
     "safe_filename",
+    "schema_from_json_schema",
     "simple_graph",
+    "StringLabelSchema",
     "UNCERTAINTY_DTYPE",
     "UndefinedInterface",
 )
@@ -34,6 +39,13 @@ __version__ = "1.3"
 
 from bw_processing.array_creation import create_array, create_structured_array
 from bw_processing.constants import DEFAULT_LICENSES, INDICES_DTYPE, UNCERTAINTY_DTYPE, MatrixSerializeFormat
+from bw_processing.param_labels import (
+    AnyLabelSchema,
+    ParamLabelField,
+    ParamLabelSchema,
+    StringLabelSchema,
+    schema_from_json_schema,
+)
 from bw_processing.datapackage import (
     Datapackage,
     DatapackageBase,

--- a/src/bw_processing/datapackage.py
+++ b/src/bw_processing/datapackage.py
@@ -522,10 +522,7 @@ class Datapackage(DatapackageBase):
         ``param_label_schema`` describes the structure of each label object and
         triggers validation on write; it requires ``param_labels``.
         """
-        if param_label_schema is not None and param_labels is None:
-            raise ValueError("`param_label_schema` requires `param_labels`")
-        if param_labels is not None and params_array is None:
-            raise ValueError("`param_labels` requires `params_array`")
+        self._check_params_args(params_array, param_labels, param_label_schema)
         self._prepare_modifications()
 
         # Check lengths
@@ -685,10 +682,7 @@ class Datapackage(DatapackageBase):
         that produced each scenario column.  See ``add_persistent_vector`` for
         the ``param_labels`` and ``param_label_schema`` arguments.
         """
-        if param_label_schema is not None and param_labels is None:
-            raise ValueError("`param_label_schema` requires `param_labels`")
-        if param_labels is not None and params_array is None:
-            raise ValueError("`param_labels` requires `params_array`")
+        self._check_params_args(params_array, param_labels, param_label_schema)
         self._prepare_modifications()
 
         kwargs.update({"matrix": matrix, "category": "array", "nrows": len(indices_array)})
@@ -900,6 +894,17 @@ class Datapackage(DatapackageBase):
             **kwargs,
         )
 
+    @staticmethod
+    def _check_params_args(
+        params_array: Optional[np.ndarray],
+        param_labels: Optional[list],
+        param_label_schema: Optional[AnyLabelSchema],
+    ) -> None:
+        if param_label_schema is not None and param_labels is None:
+            raise ValueError("`param_label_schema` requires `param_labels`")
+        if param_labels is not None and params_array is None:
+            raise ValueError("`param_labels` requires `params_array`")
+
     def _add_params_array_resource(
         self,
         *,
@@ -929,7 +934,7 @@ class Datapackage(DatapackageBase):
         self,
         *,
         param_labels: list,
-        param_label_schema: Optional[Any],
+        param_label_schema: Optional[AnyLabelSchema],
         name: str,
         **kwargs,
     ) -> None:
@@ -1070,10 +1075,7 @@ class Datapackage(DatapackageBase):
             matrix_serialize_format_type: Override the instance-level
                 serialization format for static arrays in this group.
         """
-        if param_label_schema is not None and param_labels is None:
-            raise ValueError("`param_label_schema` requires `param_labels`")
-        if param_labels is not None and params_array is None:
-            raise ValueError("`param_labels` requires `params_array`")
+        self._check_params_args(params_array, param_labels, param_label_schema)
         self._prepare_modifications()
 
         kwargs.update({"matrix": matrix, "category": "vector", "nrows": len(indices_array)})
@@ -1210,10 +1212,7 @@ class Datapackage(DatapackageBase):
             matrix_serialize_format_type: Override the instance-level
                 serialization format for static arrays in this group.
         """
-        if param_label_schema is not None and param_labels is None:
-            raise ValueError("`param_label_schema` requires `param_labels`")
-        if param_labels is not None and params_array is None:
-            raise ValueError("`param_labels` requires `params_array`")
+        self._check_params_args(params_array, param_labels, param_label_schema)
         self._prepare_modifications()
 
         if isinstance(flip_array, np.ndarray) and not flip_array.sum():

--- a/src/bw_processing/datapackage.py
+++ b/src/bw_processing/datapackage.py
@@ -37,6 +37,7 @@ from bw_processing.errors import (
 )
 from bw_processing.filesystem import clean_datapackage_name
 from bw_processing.io_helpers import file_reader, file_writer
+from bw_processing.param_labels import AnyLabelSchema
 from bw_processing.proxies import Proxy, UndefinedInterface
 from bw_processing.utils import check_name, check_suffix, load_bytes, resolve_dict_iterator, utc_now
 
@@ -497,6 +498,9 @@ class Datapackage(DatapackageBase):
         flip_array: Optional[np.ndarray] = None,
         distributions_array: Optional[np.ndarray] = None,
         scale_array: Optional[np.ndarray] = None,
+        params_array: Optional[np.ndarray] = None,
+        param_labels: Optional[list] = None,
+        param_label_schema: Optional[AnyLabelSchema] = None,
         keep_proxy: bool = False,
         matrix_serialize_format_type: Optional[MatrixSerializeFormat] = None,
         **kwargs,
@@ -509,7 +513,19 @@ class Datapackage(DatapackageBase):
         the value is inserted into the matrix.  Typical uses are allocation
         factors and unit conversions.  A value of ``1.0`` leaves the data
         unchanged.
+
+        ``params_array`` is an optional 1-D float array recording the values of
+        independent variables (e.g. model parameters) used to generate this
+        resource group.  ``param_labels`` is an optional list of label objects
+        (strings or dicts) of the same length as ``params_array``; if provided,
+        a ``name.param_labels.json`` file is written alongside the array.
+        ``param_label_schema`` describes the structure of each label object and
+        triggers validation on write; it requires ``param_labels``.
         """
+        if param_label_schema is not None and param_labels is None:
+            raise ValueError("`param_label_schema` requires `param_labels`")
+        if param_labels is not None and params_array is None:
+            raise ValueError("`param_labels` requires `params_array`")
         self._prepare_modifications()
 
         # Check lengths
@@ -609,6 +625,34 @@ class Datapackage(DatapackageBase):
                 matrix_serialize_format_type=matrix_serialize_format_type,
                 **kwargs,
             )
+        if params_array is not None:
+            params_array = load_bytes(params_array)
+            if params_array.ndim != 1:
+                raise ShapeMismatch(
+                    "`params_array` for a vector must be 1-D, got shape {}.".format(
+                        params_array.shape
+                    )
+                )
+            self._add_params_array_resource(
+                params_array=params_array,
+                name=name,
+                keep_proxy=keep_proxy,
+                matrix_serialize_format_type=matrix_serialize_format_type,
+                **kwargs,
+            )
+            if param_labels is not None:
+                if len(param_labels) != len(params_array):
+                    raise ShapeMismatch(
+                        "`param_labels` length ({}) doesn't match `params_array` ({}).".format(
+                            len(param_labels), len(params_array)
+                        )
+                    )
+                self._add_param_labels_resource(
+                    param_labels=param_labels,
+                    param_label_schema=param_label_schema,
+                    name=name,
+                    **kwargs,
+                )
 
     def add_persistent_array(
         self,
@@ -619,6 +663,9 @@ class Datapackage(DatapackageBase):
         name: Optional[str] = None,
         flip_array: Optional[np.ndarray] = None,
         scale_array: Optional[np.ndarray] = None,
+        params_array: Optional[np.ndarray] = None,
+        param_labels: Optional[list] = None,
+        param_label_schema: Optional[AnyLabelSchema] = None,
         keep_proxy: bool = False,
         matrix_serialize_format_type: Optional[MatrixSerializeFormat] = None,
         **kwargs,
@@ -631,7 +678,17 @@ class Datapackage(DatapackageBase):
         the value is inserted into the matrix.  Typical uses are allocation
         factors and unit conversions.  A value of ``1.0`` leaves the data
         unchanged.
+
+        ``params_array`` is an optional 2-D float array of shape
+        ``(n_params, n_scenarios)`` where ``n_scenarios`` must equal
+        ``data_array.shape[1]``.  It records the independent variable values
+        that produced each scenario column.  See ``add_persistent_vector`` for
+        the ``param_labels`` and ``param_label_schema`` arguments.
         """
+        if param_label_schema is not None and param_labels is None:
+            raise ValueError("`param_label_schema` requires `param_labels`")
+        if param_labels is not None and params_array is None:
+            raise ValueError("`param_labels` requires `params_array`")
         self._prepare_modifications()
 
         kwargs.update({"matrix": matrix, "category": "array", "nrows": len(indices_array)})
@@ -707,6 +764,40 @@ class Datapackage(DatapackageBase):
                 matrix_serialize_format_type=matrix_serialize_format_type,
                 **kwargs,
             )
+        if params_array is not None:
+            params_array = load_bytes(params_array)
+            if params_array.ndim != 2:
+                raise ShapeMismatch(
+                    "`params_array` for an array must be 2-D, got shape {}.".format(
+                        params_array.shape
+                    )
+                )
+            if params_array.shape[1] != data_array.shape[1]:
+                raise ShapeMismatch(
+                    "`params_array` column count ({}) doesn't match `data_array` ({}).".format(
+                        params_array.shape[1], data_array.shape[1]
+                    )
+                )
+            self._add_params_array_resource(
+                params_array=params_array,
+                name=name,
+                keep_proxy=keep_proxy,
+                matrix_serialize_format_type=matrix_serialize_format_type,
+                **kwargs,
+            )
+            if param_labels is not None:
+                if len(param_labels) != params_array.shape[0]:
+                    raise ShapeMismatch(
+                        "`param_labels` length ({}) doesn't match `params_array` rows ({}).".format(
+                            len(param_labels), params_array.shape[0]
+                        )
+                    )
+                self._add_param_labels_resource(
+                    param_labels=param_labels,
+                    param_label_schema=param_label_schema,
+                    name=name,
+                    **kwargs,
+                )
 
     def write_modified(self):
         """Flush modified resources back to the filesystem.
@@ -735,7 +826,7 @@ class Datapackage(DatapackageBase):
                     if kind == "indices":
                         meta_object = "vector"
                         meta_type = "indices"
-                    elif kind in ("flip", "scale"):
+                    elif kind in ("flip", "scale", "params"):
                         meta_object = "vector"
                         meta_type = "generic"
                     elif kind == "distributions":
@@ -756,15 +847,23 @@ class Datapackage(DatapackageBase):
                             f"Parquet format not available for resource with kind={kind}!"
                         )
 
-            file_writer(
-                data=self.data[index],
-                fs=self.fs,
-                resource=path,
-                mimetype=mediatype,
-                matrix_serialize_format_type=matrix_serialize_format_type,
-                meta_object=meta_object,
-                meta_type=meta_type,
-            )
+            if mediatype == "application/json":
+                file_writer(
+                    data=self.data[index],
+                    fs=self.fs,
+                    resource=path,
+                    mimetype=mediatype,
+                )
+            else:
+                file_writer(
+                    data=self.data[index],
+                    fs=self.fs,
+                    resource=path,
+                    mimetype=mediatype,
+                    matrix_serialize_format_type=matrix_serialize_format_type,
+                    meta_object=meta_object,
+                    meta_type=meta_type,
+                )
 
         self._modified = set()
 
@@ -800,6 +899,59 @@ class Datapackage(DatapackageBase):
             meta_type="generic",
             **kwargs,
         )
+
+    def _add_params_array_resource(
+        self,
+        *,
+        params_array: np.ndarray,
+        name: str,
+        keep_proxy: bool,
+        matrix_serialize_format_type: Optional[MatrixSerializeFormat],
+        **kwargs,
+    ) -> None:
+        if not np.issubdtype(params_array.dtype, np.floating):
+            raise WrongDatatype(
+                "`params_array` dtype is {}, but must be a float dtype".format(params_array.dtype)
+            )
+        self._add_numpy_array_resource(
+            array=params_array,
+            group=name,
+            name=name + ".params",
+            kind="params",
+            keep_proxy=keep_proxy,
+            matrix_serialize_format_type=matrix_serialize_format_type,
+            meta_object="vector",
+            meta_type="generic",
+            **kwargs,
+        )
+
+    def _add_param_labels_resource(
+        self,
+        *,
+        param_labels: list,
+        param_label_schema: Optional[Any],
+        name: str,
+        **kwargs,
+    ) -> None:
+        data: dict = {"values": param_labels}
+        if param_label_schema is not None:
+            param_label_schema.validate(param_labels)
+            data["schema"] = param_label_schema.to_json_schema()
+
+        filename = check_suffix(name + ".param_labels", ".json")
+        file_writer(data=data, fs=self.fs, resource=filename, mimetype="application/json")
+        self.data.append(data)
+
+        resource: dict = {
+            "profile": "data-resource",
+            "mediatype": "application/json",
+            "path": str(filename),
+            "name": name + ".param_labels",
+            "kind": "param_labels",
+            "group": name,
+        }
+        resource.update(**kwargs)
+        self.resources.append(resource)
 
     def _add_numpy_array_resource(
         self,
@@ -884,6 +1036,9 @@ class Datapackage(DatapackageBase):
         name: Optional[str] = None,
         flip_array: Optional[np.ndarray] = None,  # Not interface
         scale_array: Optional[np.ndarray] = None,  # Not interface
+        params_array: Optional[np.ndarray] = None,  # Not interface
+        param_labels: Optional[list] = None,
+        param_label_schema: Optional[AnyLabelSchema] = None,
         keep_proxy: bool = False,
         matrix_serialize_format_type: Optional[MatrixSerializeFormat] = None,
         **kwargs,
@@ -894,8 +1049,10 @@ class Datapackage(DatapackageBase):
         stored on disk. ``interface`` must implement ``__next__()`` and return a
         1-D numpy array of length ``len(indices_array)`` each time it is called.
 
-        The ``indices_array``, optional ``flip_array``, and optional
-        ``scale_array`` are static and are stored as normal numpy resources.
+        The ``indices_array``, optional ``flip_array``, optional ``scale_array``,
+        and optional ``params_array`` are static and are stored as normal numpy
+        resources.  See ``add_persistent_vector`` for documentation of the
+        ``params_array``, ``param_labels``, and ``param_label_schema`` arguments.
 
         Args:
             matrix: Name of the target matrix.
@@ -913,6 +1070,10 @@ class Datapackage(DatapackageBase):
             matrix_serialize_format_type: Override the instance-level
                 serialization format for static arrays in this group.
         """
+        if param_label_schema is not None and param_labels is None:
+            raise ValueError("`param_label_schema` requires `param_labels`")
+        if param_labels is not None and params_array is None:
+            raise ValueError("`param_labels` requires `params_array`")
         self._prepare_modifications()
 
         kwargs.update({"matrix": matrix, "category": "vector", "nrows": len(indices_array)})
@@ -963,6 +1124,34 @@ class Datapackage(DatapackageBase):
                 matrix_serialize_format_type=matrix_serialize_format_type,
                 **kwargs,
             )
+        if params_array is not None:
+            params_array = load_bytes(params_array)
+            if params_array.ndim != 1:
+                raise ShapeMismatch(
+                    "`params_array` for a vector must be 1-D, got shape {}.".format(
+                        params_array.shape
+                    )
+                )
+            self._add_params_array_resource(
+                params_array=params_array,
+                name=name,
+                keep_proxy=keep_proxy,
+                matrix_serialize_format_type=matrix_serialize_format_type,
+                **kwargs,
+            )
+            if param_labels is not None:
+                if len(param_labels) != len(params_array):
+                    raise ShapeMismatch(
+                        "`param_labels` length ({}) doesn't match `params_array` ({}).".format(
+                            len(param_labels), len(params_array)
+                        )
+                    )
+                self._add_param_labels_resource(
+                    param_labels=param_labels,
+                    param_label_schema=param_label_schema,
+                    name=name,
+                    **kwargs,
+                )
 
         self.data.append(interface)
         resource = {
@@ -983,6 +1172,9 @@ class Datapackage(DatapackageBase):
         name: Optional[str] = None,
         flip_array: Optional[np.ndarray] = None,
         scale_array: Optional[np.ndarray] = None,  # Not interface
+        params_array: Optional[np.ndarray] = None,  # Not interface
+        param_labels: Optional[list] = None,
+        param_label_schema: Optional[AnyLabelSchema] = None,
         keep_proxy: bool = False,
         matrix_serialize_format_type: Optional[MatrixSerializeFormat] = None,
         **kwargs,
@@ -995,8 +1187,12 @@ class Datapackage(DatapackageBase):
         array for ``args[1]``.  ``ncols`` may be ``None`` for an infinite
         interface.
 
-        The ``indices_array``, optional ``flip_array``, and optional
-        ``scale_array`` are static and are stored as normal numpy resources.
+        The ``indices_array``, optional ``flip_array``, optional ``scale_array``,
+        and optional ``params_array`` are static and are stored as normal numpy
+        resources.  For dynamic arrays the column count of ``params_array`` is
+        not validated against the interface (whose column count may be unknown at
+        write time).  See ``add_persistent_vector`` for documentation of the
+        ``params_array``, ``param_labels``, and ``param_label_schema`` arguments.
 
         Args:
             matrix: Name of the target matrix.
@@ -1014,6 +1210,10 @@ class Datapackage(DatapackageBase):
             matrix_serialize_format_type: Override the instance-level
                 serialization format for static arrays in this group.
         """
+        if param_label_schema is not None and param_labels is None:
+            raise ValueError("`param_label_schema` requires `param_labels`")
+        if param_labels is not None and params_array is None:
+            raise ValueError("`param_labels` requires `params_array`")
         self._prepare_modifications()
 
         if isinstance(flip_array, np.ndarray) and not flip_array.sum():
@@ -1067,6 +1267,34 @@ class Datapackage(DatapackageBase):
                 matrix_serialize_format_type=matrix_serialize_format_type,
                 **kwargs,
             )
+        if params_array is not None:
+            params_array = load_bytes(params_array)
+            if params_array.ndim != 2:
+                raise ShapeMismatch(
+                    "`params_array` for an array must be 2-D, got shape {}.".format(
+                        params_array.shape
+                    )
+                )
+            self._add_params_array_resource(
+                params_array=params_array,
+                name=name,
+                keep_proxy=keep_proxy,
+                matrix_serialize_format_type=matrix_serialize_format_type,
+                **kwargs,
+            )
+            if param_labels is not None:
+                if len(param_labels) != params_array.shape[0]:
+                    raise ShapeMismatch(
+                        "`param_labels` length ({}) doesn't match `params_array` rows ({}).".format(
+                            len(param_labels), params_array.shape[0]
+                        )
+                    )
+                self._add_param_labels_resource(
+                    param_labels=param_labels,
+                    param_label_schema=param_label_schema,
+                    name=name,
+                    **kwargs,
+                )
 
         self.data.append(interface)
         resource = {

--- a/src/bw_processing/param_labels.py
+++ b/src/bw_processing/param_labels.py
@@ -2,6 +2,8 @@ import jsonschema
 from dataclasses import dataclass, field
 from typing import Dict, List, Literal, Optional, Union
 
+VALID_FIELD_TYPES = ("string", "integer", "number", "boolean")
+
 
 @dataclass
 class StringLabelSchema:
@@ -69,15 +71,22 @@ class ParamLabelSchema:
     @classmethod
     def from_json_schema(cls, data: Dict) -> "ParamLabelSchema":
         required = set(data.get("required", []))
-        fields = [
-            ParamLabelField(
-                name=name,
-                type=defn.get("type", "string"),
-                required=name in required,
-                description=defn.get("description"),
+        fields = []
+        for name, defn in data.get("properties", {}).items():
+            type_val = defn.get("type", "string")
+            if type_val not in VALID_FIELD_TYPES:
+                raise ValueError(
+                    f"Unknown field type {type_val!r} for field {name!r}; "
+                    f"must be one of {VALID_FIELD_TYPES}"
+                )
+            fields.append(
+                ParamLabelField(
+                    name=name,
+                    type=type_val,
+                    required=name in required,
+                    description=defn.get("description"),
+                )
             )
-            for name, defn in data.get("properties", {}).items()
-        ]
         return cls(fields=fields, description=data.get("description"))
 
 

--- a/src/bw_processing/param_labels.py
+++ b/src/bw_processing/param_labels.py
@@ -1,0 +1,91 @@
+import jsonschema
+from dataclasses import dataclass, field
+from typing import Dict, List, Literal, Optional, Union
+
+
+@dataclass
+class StringLabelSchema:
+    """Schema for param labels that are plain strings."""
+
+    description: Optional[str] = None
+
+    def to_json_schema(self) -> Dict:
+        s: Dict = {"type": "string"}
+        if self.description:
+            s["description"] = self.description
+        return s
+
+    def validate(self, values: List) -> None:
+        schema = self.to_json_schema()
+        for value in values:
+            jsonschema.validate(value, schema)
+
+    @classmethod
+    def from_json_schema(cls, data: Dict) -> "StringLabelSchema":
+        return cls(description=data.get("description"))
+
+
+@dataclass
+class ParamLabelField:
+    """A single field in a structured param label."""
+
+    name: str
+    type: Literal["string", "integer", "number", "boolean"] = "string"
+    required: bool = True
+    description: Optional[str] = None
+
+
+@dataclass
+class ParamLabelSchema:
+    """Schema for param labels that are structured objects."""
+
+    fields: List[ParamLabelField] = field(default_factory=list)
+    description: Optional[str] = None
+
+    def to_json_schema(self) -> Dict:
+        s: Dict = {
+            "type": "object",
+            "properties": {
+                f.name: {
+                    k: v
+                    for k, v in {"type": f.type, "description": f.description}.items()
+                    if v is not None
+                }
+                for f in self.fields
+            },
+        }
+        required = [f.name for f in self.fields if f.required]
+        if required:
+            s["required"] = required
+        if self.description:
+            s["description"] = self.description
+        return s
+
+    def validate(self, values: List) -> None:
+        schema = self.to_json_schema()
+        for value in values:
+            jsonschema.validate(value, schema)
+
+    @classmethod
+    def from_json_schema(cls, data: Dict) -> "ParamLabelSchema":
+        required = set(data.get("required", []))
+        fields = [
+            ParamLabelField(
+                name=name,
+                type=defn.get("type", "string"),
+                required=name in required,
+                description=defn.get("description"),
+            )
+            for name, defn in data.get("properties", {}).items()
+        ]
+        return cls(fields=fields, description=data.get("description"))
+
+
+AnyLabelSchema = Union[StringLabelSchema, ParamLabelSchema]
+
+
+def schema_from_json_schema(data: Dict) -> AnyLabelSchema:
+    """Reconstruct a StringLabelSchema or ParamLabelSchema from a stored JSON Schema dict."""
+    if data.get("type") == "string":
+        return StringLabelSchema.from_json_schema(data)
+    return ParamLabelSchema.from_json_schema(data)

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -1,0 +1,371 @@
+import numpy as np
+import pytest
+
+from bw_processing import (
+    INDICES_DTYPE,
+    ParamLabelField,
+    ParamLabelSchema,
+    StringLabelSchema,
+    create_datapackage,
+    generic_directory_filesystem,
+    load_datapackage,
+    schema_from_json_schema,
+)
+from bw_processing.errors import ShapeMismatch, WrongDatatype
+
+
+# ---------------------------------------------------------------------------
+# StringLabelSchema
+# ---------------------------------------------------------------------------
+
+
+def test_string_label_schema_to_json_schema():
+    assert StringLabelSchema().to_json_schema() == {"type": "string"}
+
+
+def test_string_label_schema_with_description():
+    s = StringLabelSchema(description="A name")
+    assert s.to_json_schema() == {"type": "string", "description": "A name"}
+
+
+def test_string_label_schema_round_trip():
+    s = StringLabelSchema(description="test")
+    assert StringLabelSchema.from_json_schema(s.to_json_schema()) == s
+
+
+def test_string_label_schema_validation_passes():
+    StringLabelSchema().validate(["temperature", "pressure"])
+
+
+def test_string_label_schema_validation_fails():
+    with pytest.raises(Exception):  # jsonschema.ValidationError
+        StringLabelSchema().validate([{"not": "a string"}])
+
+
+# ---------------------------------------------------------------------------
+# ParamLabelField / ParamLabelSchema
+# ---------------------------------------------------------------------------
+
+
+def test_param_label_schema_to_json_schema():
+    schema = ParamLabelSchema(
+        fields=[
+            ParamLabelField(name="name", type="string", required=True),
+            ParamLabelField(name="value", type="number", required=False),
+        ]
+    )
+    result = schema.to_json_schema()
+    assert result["type"] == "object"
+    assert set(result["properties"]) == {"name", "value"}
+    assert result["required"] == ["name"]
+    assert "value" not in result.get("required", [])
+
+
+def test_param_label_schema_no_required_omitted():
+    schema = ParamLabelSchema(
+        fields=[ParamLabelField(name="x", type="number", required=False)]
+    )
+    result = schema.to_json_schema()
+    assert "required" not in result
+
+
+def test_param_label_schema_field_description():
+    schema = ParamLabelSchema(
+        fields=[ParamLabelField(name="db", type="string", description="Database name")]
+    )
+    result = schema.to_json_schema()
+    assert result["properties"]["db"]["description"] == "Database name"
+
+
+def test_param_label_schema_round_trip():
+    schema = ParamLabelSchema(
+        fields=[
+            ParamLabelField(name="database", type="string", required=True, description="DB"),
+            ParamLabelField(name="amount", type="number", required=False),
+        ]
+    )
+    assert ParamLabelSchema.from_json_schema(schema.to_json_schema()) == schema
+
+
+def test_param_label_schema_validation_passes():
+    schema = ParamLabelSchema(fields=[ParamLabelField(name="name", type="string")])
+    schema.validate([{"name": "electricity"}, {"name": "heat"}])
+
+
+def test_param_label_schema_validation_fails_missing_required():
+    schema = ParamLabelSchema(fields=[ParamLabelField(name="name", type="string", required=True)])
+    with pytest.raises(Exception):  # jsonschema.ValidationError
+        schema.validate([{"other": "field"}])
+
+
+def test_param_label_schema_validation_fails_wrong_type():
+    schema = ParamLabelSchema(fields=[ParamLabelField(name="amount", type="number")])
+    with pytest.raises(Exception):
+        schema.validate([{"amount": "not-a-number"}])
+
+
+# ---------------------------------------------------------------------------
+# schema_from_json_schema factory
+# ---------------------------------------------------------------------------
+
+
+def test_schema_from_json_schema_string():
+    assert isinstance(schema_from_json_schema({"type": "string"}), StringLabelSchema)
+
+
+def test_schema_from_json_schema_object():
+    result = schema_from_json_schema(
+        {
+            "type": "object",
+            "properties": {"name": {"type": "string"}},
+            "required": ["name"],
+        }
+    )
+    assert isinstance(result, ParamLabelSchema)
+    assert len(result.fields) == 1
+    assert result.fields[0].name == "name"
+    assert result.fields[0].required is True
+
+
+# ---------------------------------------------------------------------------
+# add_persistent_vector with params
+# ---------------------------------------------------------------------------
+
+
+def _make_indices(n=1):
+    return np.array([(i, i + 1) for i in range(n)], dtype=INDICES_DTYPE)
+
+
+def test_persistent_vector_params_only():
+    dp = create_datapackage()
+    dp.add_persistent_vector(
+        matrix="technosphere",
+        indices_array=_make_indices(),
+        data_array=np.array([1.0]),
+        params_array=np.array([25.0, 1.013]),
+        name="test",
+    )
+    kinds = {r["kind"] for r in dp.resources}
+    assert "params" in kinds
+    assert "param_labels" not in kinds
+
+
+def test_persistent_vector_params_with_string_labels():
+    dp = create_datapackage()
+    dp.add_persistent_vector(
+        matrix="technosphere",
+        indices_array=_make_indices(),
+        data_array=np.array([1.0]),
+        params_array=np.array([25.0, 1.013]),
+        param_labels=["temperature", "pressure"],
+        name="test",
+    )
+    kinds = {r["kind"] for r in dp.resources}
+    assert "params" in kinds
+    assert "param_labels" in kinds
+    labels_data, _ = dp.get_resource("test.param_labels")
+    assert labels_data["values"] == ["temperature", "pressure"]
+    assert "schema" not in labels_data
+
+
+def test_persistent_vector_params_with_schema():
+    dp = create_datapackage()
+    schema = ParamLabelSchema(
+        fields=[
+            ParamLabelField(name="name", type="string"),
+            ParamLabelField(name="namespace", type="string"),
+        ]
+    )
+    dp.add_persistent_vector(
+        matrix="technosphere",
+        indices_array=_make_indices(),
+        data_array=np.array([1.0]),
+        params_array=np.array([25.0]),
+        param_labels=[{"name": "temperature", "namespace": "IEA"}],
+        param_label_schema=schema,
+        name="test",
+    )
+    labels_data, _ = dp.get_resource("test.param_labels")
+    assert labels_data["values"] == [{"name": "temperature", "namespace": "IEA"}]
+    assert labels_data["schema"]["type"] == "object"
+    assert "required" in labels_data["schema"]
+
+
+def test_persistent_vector_params_with_string_schema():
+    dp = create_datapackage()
+    dp.add_persistent_vector(
+        matrix="technosphere",
+        indices_array=_make_indices(),
+        data_array=np.array([1.0]),
+        params_array=np.array([25.0]),
+        param_labels=["temperature"],
+        param_label_schema=StringLabelSchema(),
+        name="test",
+    )
+    labels_data, _ = dp.get_resource("test.param_labels")
+    assert labels_data["schema"] == {"type": "string"}
+
+
+def test_persistent_vector_params_all_resources_in_group():
+    dp = create_datapackage()
+    dp.add_persistent_vector(
+        matrix="technosphere",
+        indices_array=_make_indices(),
+        data_array=np.array([1.0]),
+        params_array=np.array([25.0]),
+        param_labels=["temperature"],
+        name="test",
+    )
+    groups = dp.groups
+    assert "test" in groups
+    group_kinds = {r["kind"] for r in groups["test"].resources}
+    assert group_kinds == {"indices", "data", "params", "param_labels"}
+
+
+# ---------------------------------------------------------------------------
+# Error cases for persistent_vector
+# ---------------------------------------------------------------------------
+
+
+def test_persistent_vector_params_wrong_dtype():
+    dp = create_datapackage()
+    with pytest.raises(WrongDatatype):
+        dp.add_persistent_vector(
+            matrix="technosphere",
+            indices_array=_make_indices(),
+            params_array=np.array([1, 2], dtype=int),
+            name="test",
+        )
+
+
+def test_persistent_vector_params_must_be_1d():
+    dp = create_datapackage()
+    with pytest.raises(ShapeMismatch):
+        dp.add_persistent_vector(
+            matrix="technosphere",
+            indices_array=_make_indices(),
+            params_array=np.array([[1.0, 2.0]]),
+            name="test",
+        )
+
+
+def test_persistent_vector_labels_without_params_raises():
+    dp = create_datapackage()
+    with pytest.raises(ValueError):
+        dp.add_persistent_vector(
+            matrix="technosphere",
+            indices_array=_make_indices(),
+            param_labels=["temperature"],
+            name="test",
+        )
+
+
+def test_persistent_vector_schema_without_labels_raises():
+    dp = create_datapackage()
+    with pytest.raises(ValueError):
+        dp.add_persistent_vector(
+            matrix="technosphere",
+            indices_array=_make_indices(),
+            params_array=np.array([1.0]),
+            param_label_schema=StringLabelSchema(),
+            name="test",
+        )
+
+
+def test_persistent_vector_labels_length_mismatch():
+    dp = create_datapackage()
+    with pytest.raises(ShapeMismatch):
+        dp.add_persistent_vector(
+            matrix="technosphere",
+            indices_array=_make_indices(),
+            params_array=np.array([1.0, 2.0]),
+            param_labels=["only_one_label"],
+            name="test",
+        )
+
+
+# ---------------------------------------------------------------------------
+# add_persistent_array with params
+# ---------------------------------------------------------------------------
+
+
+def test_persistent_array_params():
+    dp = create_datapackage()
+    indices = _make_indices(2)
+    data = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])  # 2 exchanges, 3 scenarios
+    params = np.array([[10.0, 20.0, 30.0], [1.0, 2.0, 3.0]])  # 2 params, 3 scenarios
+    dp.add_persistent_array(
+        matrix="technosphere",
+        indices_array=indices,
+        data_array=data,
+        params_array=params,
+        param_labels=["temperature", "pressure"],
+        name="test",
+    )
+    kinds = {r["kind"] for r in dp.resources}
+    assert "params" in kinds
+    assert "param_labels" in kinds
+    params_data, _ = dp.get_resource("test.params")
+    assert params_data.shape == (2, 3)
+
+
+def test_persistent_array_params_column_mismatch():
+    dp = create_datapackage()
+    indices = _make_indices(1)
+    data = np.array([[1.0, 2.0, 3.0]])  # 3 scenarios
+    params = np.array([[10.0, 20.0]])   # only 2 scenarios — mismatch
+    with pytest.raises(ShapeMismatch):
+        dp.add_persistent_array(
+            matrix="technosphere",
+            indices_array=indices,
+            data_array=data,
+            params_array=params,
+            name="test",
+        )
+
+
+def test_persistent_array_params_must_be_2d():
+    dp = create_datapackage()
+    indices = _make_indices(1)
+    data = np.array([[1.0, 2.0]])
+    with pytest.raises(ShapeMismatch):
+        dp.add_persistent_array(
+            matrix="technosphere",
+            indices_array=indices,
+            data_array=data,
+            params_array=np.array([1.0, 2.0]),  # 1D — wrong for array
+            name="test",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Round-trip (serialize + reload)
+# ---------------------------------------------------------------------------
+
+
+def test_round_trip_with_params_and_labels(tmp_path):
+    fs = generic_directory_filesystem(dirpath=tmp_path / "dp")
+    dp = create_datapackage(fs=fs)
+    schema = ParamLabelSchema(
+        fields=[ParamLabelField(name="name", type="string"), ParamLabelField(name="db", type="string")]
+    )
+    dp.add_persistent_vector(
+        matrix="technosphere",
+        indices_array=_make_indices(),
+        data_array=np.array([1.0]),
+        params_array=np.array([25.0]),
+        param_labels=[{"name": "temperature", "db": "ecoinvent"}],
+        param_label_schema=schema,
+        name="test",
+    )
+    dp.finalize_serialization()
+
+    dp2 = load_datapackage(generic_directory_filesystem(dirpath=tmp_path / "dp"))
+    params_data, _ = dp2.get_resource("test.params")
+    labels_data, _ = dp2.get_resource("test.param_labels")
+
+    np.testing.assert_array_equal(params_data, np.array([25.0]))
+    assert labels_data["values"] == [{"name": "temperature", "db": "ecoinvent"}]
+    reconstructed = schema_from_json_schema(labels_data["schema"])
+    assert isinstance(reconstructed, ParamLabelSchema)
+    assert reconstructed == schema

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -1,3 +1,4 @@
+import jsonschema
 import numpy as np
 import pytest
 
@@ -38,7 +39,7 @@ def test_string_label_schema_validation_passes():
 
 
 def test_string_label_schema_validation_fails():
-    with pytest.raises(Exception):  # jsonschema.ValidationError
+    with pytest.raises(jsonschema.ValidationError):
         StringLabelSchema().validate([{"not": "a string"}])
 
 
@@ -94,13 +95,13 @@ def test_param_label_schema_validation_passes():
 
 def test_param_label_schema_validation_fails_missing_required():
     schema = ParamLabelSchema(fields=[ParamLabelField(name="name", type="string", required=True)])
-    with pytest.raises(Exception):  # jsonschema.ValidationError
+    with pytest.raises(jsonschema.ValidationError):
         schema.validate([{"other": "field"}])
 
 
 def test_param_label_schema_validation_fails_wrong_type():
     schema = ParamLabelSchema(fields=[ParamLabelField(name="amount", type="number")])
-    with pytest.raises(Exception):
+    with pytest.raises(jsonschema.ValidationError):
         schema.validate([{"amount": "not-a-number"}])
 
 
@@ -369,3 +370,114 @@ def test_round_trip_with_params_and_labels(tmp_path):
     reconstructed = schema_from_json_schema(labels_data["schema"])
     assert isinstance(reconstructed, ParamLabelSchema)
     assert reconstructed == schema
+
+
+def test_round_trip_persistent_array_with_params(tmp_path):
+    fs = generic_directory_filesystem(dirpath=tmp_path / "dp")
+    dp = create_datapackage(fs=fs)
+    dp.add_persistent_array(
+        matrix="technosphere",
+        indices_array=_make_indices(2),
+        data_array=np.array([[1.0, 2.0], [3.0, 4.0]]),
+        params_array=np.array([[10.0, 20.0]]),  # 1 param, 2 scenarios
+        param_labels=["temperature"],
+        param_label_schema=StringLabelSchema(),
+        name="test",
+    )
+    dp.finalize_serialization()
+
+    dp2 = load_datapackage(generic_directory_filesystem(dirpath=tmp_path / "dp"))
+    params_data, _ = dp2.get_resource("test.params")
+    assert params_data.shape == (1, 2)
+    np.testing.assert_array_equal(params_data, np.array([[10.0, 20.0]]))
+
+
+# ---------------------------------------------------------------------------
+# from_json_schema type validation
+# ---------------------------------------------------------------------------
+
+
+def test_from_json_schema_rejects_unknown_type():
+    with pytest.raises(ValueError, match="Unknown field type"):
+        ParamLabelSchema.from_json_schema(
+            {"type": "object", "properties": {"x": {"type": "array"}}}
+        )
+
+
+# ---------------------------------------------------------------------------
+# Write-time schema validation failure
+# ---------------------------------------------------------------------------
+
+
+def test_write_time_validation_failure():
+    dp = create_datapackage()
+    schema = ParamLabelSchema(fields=[ParamLabelField(name="name", type="string")])
+    with pytest.raises(jsonschema.ValidationError):
+        dp.add_persistent_vector(
+            matrix="technosphere",
+            indices_array=_make_indices(),
+            data_array=np.array([1.0]),
+            params_array=np.array([25.0]),
+            param_labels=[{"name": 42}],  # "name" should be a string, not an int
+            param_label_schema=schema,
+            name="test",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Dynamic vector and array with params
+# ---------------------------------------------------------------------------
+
+
+class _DummyInterface:
+    pass
+
+
+def test_dynamic_vector_with_params():
+    dp = create_datapackage()
+    dp.add_dynamic_vector(
+        matrix="technosphere",
+        interface=_DummyInterface(),
+        indices_array=_make_indices(),
+        params_array=np.array([25.0, 1.013]),
+        param_labels=["temperature", "pressure"],
+        param_label_schema=StringLabelSchema(),
+        name="test",
+    )
+    kinds = {r["kind"] for r in dp.resources}
+    assert "params" in kinds
+    assert "param_labels" in kinds
+    labels_data, _ = dp.get_resource("test.param_labels")
+    assert labels_data["values"] == ["temperature", "pressure"]
+    assert labels_data["schema"] == {"type": "string"}
+
+
+def test_dynamic_array_with_params():
+    dp = create_datapackage()
+    # 2 params, 3 scenarios — column count not validated against the interface
+    dp.add_dynamic_array(
+        matrix="technosphere",
+        interface=_DummyInterface(),
+        indices_array=_make_indices(),
+        params_array=np.array([[10.0, 20.0, 30.0], [1.0, 2.0, 3.0]]),
+        param_labels=["temperature", "pressure"],
+        param_label_schema=StringLabelSchema(),
+        name="test",
+    )
+    kinds = {r["kind"] for r in dp.resources}
+    assert "params" in kinds
+    assert "param_labels" in kinds
+    params_data, _ = dp.get_resource("test.params")
+    assert params_data.shape == (2, 3)
+
+
+def test_dynamic_array_params_must_be_2d():
+    dp = create_datapackage()
+    with pytest.raises(ShapeMismatch):
+        dp.add_dynamic_array(
+            matrix="technosphere",
+            interface=_DummyInterface(),
+            indices_array=_make_indices(),
+            params_array=np.array([1.0, 2.0]),  # 1D — wrong for array
+            name="test",
+        )


### PR DESCRIPTION
## Summary

- Adds an optional `params_array` to all four resource-group creation methods (`add_persistent_vector`, `add_persistent_array`, `add_dynamic_vector`, `add_dynamic_array`) to record the independent variable values (model parameters) that produced each data column — the foundation for global sensitivity analysis (Morris, Sobol, etc.)
- New `param_labels.py` module with `StringLabelSchema`, `ParamLabelField`, and `ParamLabelSchema` dataclasses; each serialises to a valid [JSON Schema](https://json-schema.org/) document via `to_json_schema()` and validates labels at write time using the `jsonschema` library
- Labels stored in a companion `name.param_labels.json` file inside the same resource group (`kind="param_labels"`), with `{"schema": ..., "values": [...]}` structure; no inline metadata in `datapackage.json`
- `jsonschema` added as a required dependency
- 28 new tests; README updated with a full new section including examples

## Shape rules

| Resource type | `params_array` shape | Validated against |
|---|---|---|
| vector (persistent or dynamic) | `(n_params,)` | — |
| persistent array | `(n_params, n_scenarios)` | `data_array.shape[1]` |
| dynamic array | `(n_params, n_scenarios)` | not validated (interface column count may be unknown) |

## Test plan

- [x] `StringLabelSchema` and `ParamLabelSchema` round-trip through `to_json_schema()` / `from_json_schema()`
- [x] `schema_from_json_schema()` factory dispatches correctly
- [x] `validate()` passes for conforming labels and raises `jsonschema.ValidationError` for non-conforming ones
- [x] `add_persistent_vector` with `params_array` only, with labels, and with schema
- [x] `add_persistent_array` with `params_array` — column-count mismatch raises `ShapeMismatch`
- [x] Wrong dtype, wrong ndim, `param_labels` without `params_array`, `param_label_schema` without `param_labels` all raise expected errors
- [x] Full serialize-and-reload round-trip: params array and labels file load correctly, schema reconstructs to equal dataclass
- [x] All 195 pre-existing tests still pass