### PR TITLE
Fix StopIteration crash in create_array with empty generator

### DIFF
--- a/src/bw_processing/array_creation.py
+++ b/src/bw_processing/array_creation.py
@@ -152,7 +152,10 @@ def create_array(iterable, nrows=None, dtype=np.float32):
             array[i, :] = tuple(row)
 
     else:
-        ncols, data = get_ncols(iterable)
+        try:
+            ncols, data = get_ncols(iterable)
+        except StopIteration:
+            return np.zeros((0, 0), dtype=dtype)
         array = create_chunked_array(data, ncols, dtype)
 
     return array

--- a/tests/test_array_creation.py
+++ b/tests/test_array_creation.py
@@ -1,4 +1,6 @@
-from bw_processing.array_creation import chunked
+import numpy as np
+
+from bw_processing.array_creation import chunked, create_array
 
 
 def test_chunked():
@@ -12,3 +14,23 @@ def test_chunked():
     for x in next(c):
         pass
     assert x == 599
+
+
+def test_create_array_empty_generator_returns_empty_array():
+    # Empty generator with no nrows previously raised StopIteration (issue #96)
+    result = create_array(x for x in [])
+    assert result.shape == (0, 0)
+    assert result.dtype == np.float32
+
+
+def test_create_array_empty_generator_respects_dtype():
+    result = create_array((x for x in []), dtype=np.float64)
+    assert result.dtype == np.float64
+
+
+def test_create_array_nonempty_generator():
+    data = ([float(i), float(i * 2)] for i in range(5))
+    result = create_array(data)
+    assert result.shape == (5, 2)
+    assert np.allclose(result[:, 0], [0, 1, 2, 3, 4])
+    assert np.allclose(result[:, 1], [0, 2, 4, 6, 8])


### PR DESCRIPTION
## Summary

- `create_array` crashed with `StopIteration` when passed an empty generator and no `nrows`, because `get_ncols()` → `peek()` → `next()` consumed the first element of an empty iterator with no guard
- `create_structured_array` already handled this correctly by delegating directly to `create_chunked_structured_array`, which has an explicit empty-iterable fallback
- Added a `try/except StopIteration` in the `else`-branch of `create_array` to return `np.zeros((0, 0), dtype=dtype)` when the iterator is empty

Closes #96.

## Test plan

- [ ] `test_create_array_empty_generator_returns_empty_array` — empty generator returns shape `(0, 0)` with default dtype
- [ ] `test_create_array_empty_generator_respects_dtype` — dtype is preserved on the empty result
- [ ] `test_create_array_nonempty_generator` — non-empty generator still produces correct shape and values (regression)