### PR TITLE
Deduplicate chunked bucket-fill logic; fix #95 and #97 in the process

### DIFF
--- a/src/bw_processing/array_creation.py
+++ b/src/bw_processing/array_creation.py
@@ -21,46 +21,50 @@ def chunked(iterable, chunk_size):
     return iter(lambda: list(itertools.islice(iterable, chunk_size)), [])
 
 
-def create_chunked_structured_array(iterable, dtype, bucket_size=20000):
-    """Create a numpy structured array from an iterable of indeterminate length.
+def _fill_chunked(iterable, bucket_shape, empty_shape, dtype, bucket_size):
+    """Fill a numpy array from an iterable of unknown length using fixed-size buckets.
 
-    Needed when we can't determine the length of the iterable ahead of time (e.g. for a generator or a database cursor), so can't create the complete array in memory in on step
-
-    Creates a list of arrays with ``bucket_size`` rows until ``iterable`` is exhausted, then concatenates them.
-
-    Args:
-        iterable: Iterable of data used to populate the array.
-        dtype: Numpy dtype of the created array
-        format_function: If provided, this function will be called on each row of ``iterable`` before insertion in the array.
-        bucket_size: Number of rows in each intermediate array.
-
-    Returns:.
-        Returns the created array. Will return a zero-length array if ``iterable`` has no data.
-
+    Works for both 1D structured arrays (bucket_shape=(n,)) and 2D plain arrays
+    (bucket_shape=(n, ncols)).  Concatenates along axis=0 in both cases.
     """
     arrays = []
-    array = np.zeros(bucket_size, dtype=dtype)
-
+    array = np.zeros(bucket_shape, dtype=dtype)
     for chunk in chunked(iterable, bucket_size):
         for i, row in enumerate(chunk):
             array[i] = row
         if i < bucket_size - 1:
-            array = array[: i + 1]
-            arrays.append(array)
+            # .copy() releases the oversized bucket buffer immediately rather
+            # than keeping it alive as a view until the final concatenation.
+            arrays.append(array[: i + 1].copy())
         else:
             arrays.append(array)
-            array = np.zeros(bucket_size, dtype=dtype)
-
-    # Empty iterable - create zero-length array
+            array = np.zeros(bucket_shape, dtype=dtype)
+    # Empty iterable - create zero-length array.
     # Needed because we return iterators for SQL databases
-    # but don't know if e.g. sometime a database has
-    # no biosphere exchanges
-    if arrays:
-        array = np.hstack(arrays)
-    else:
-        array = np.zeros(0, dtype=dtype)
+    # but don't know if e.g. sometimes a database has no biosphere exchanges.
+    return np.concatenate(arrays, axis=0) if arrays else np.zeros(empty_shape, dtype=dtype)
 
-    return array
+
+def create_chunked_structured_array(iterable, dtype, bucket_size=20000):
+    """Create a numpy structured array from an iterable of indeterminate length.
+
+    Needed when we can't determine the length of the iterable ahead of time
+    (e.g. for a generator or a database cursor), so can't create the complete
+    array in memory in one step.
+
+    Creates a list of arrays with ``bucket_size`` rows until ``iterable`` is
+    exhausted, then concatenates them.
+
+    Args:
+        iterable: Iterable of data used to populate the array.
+        dtype: Numpy dtype of the created array.
+        bucket_size: Number of rows in each intermediate array.
+
+    Returns:
+        Returns the created array. Will return a zero-length array if
+        ``iterable`` has no data.
+    """
+    return _fill_chunked(iterable, (bucket_size,), (0,), dtype, bucket_size)
 
 
 def create_structured_array(iterable, dtype, nrows=None, sort=False, sort_fields=None):
@@ -96,39 +100,24 @@ def create_structured_array(iterable, dtype, nrows=None, sort=False, sort_fields
 def create_chunked_array(iterable, ncols, dtype=np.float32, bucket_size=500):
     """Create a numpy array from an iterable of indeterminate length.
 
-    Needed when we can't determine the length of the iterable ahead of time (e.g. for a generator or a database cursor), so can't create the complete array in memory in on step
+    Needed when we can't determine the length of the iterable ahead of time
+    (e.g. for a generator or a database cursor), so can't create the complete
+    array in memory in one step.
 
-    Creates a list of arrays with ``bucket_size`` rows until ``iterable`` is exhausted, then concatenates them.
+    Creates a list of arrays with ``bucket_size`` rows until ``iterable`` is
+    exhausted, then concatenates them.
 
     Args:
         iterable: Iterable of data used to populate the array.
         ncols: Number of columns in the created array.
-        dtype: Numpy dtype of the created array
+        dtype: Numpy dtype of the created array.
         bucket_size: Number of rows in each intermediate array.
 
-    Returns:.
-        Returns the created array. Will return a zero-length array if ``iterable`` has no data.
-
+    Returns:
+        Returns the created array. Will return a zero-length array if
+        ``iterable`` has no data.
     """
-    arrays = []
-    array = np.zeros((bucket_size, ncols), dtype=dtype)
-
-    for chunk in chunked(iterable, bucket_size):
-        for i, row in enumerate(chunk):
-            array[i, :] = row
-        if i < bucket_size - 1:
-            array = array[: i + 1, :]
-            arrays.append(array)
-        else:
-            arrays.append(array)
-            array = np.zeros((bucket_size, ncols), dtype=dtype)
-
-    if arrays:
-        array = np.hstack(arrays)
-    else:
-        array = np.zeros((0, ncols), dtype=dtype)
-
-    return array
+    return _fill_chunked(iterable, (bucket_size, ncols), (0, ncols), dtype, bucket_size)
 
 
 def create_array(iterable, nrows=None, dtype=np.float32):

--- a/src/bw_processing/array_creation.py
+++ b/src/bw_processing/array_creation.py
@@ -21,12 +21,29 @@ def chunked(iterable, chunk_size):
     return iter(lambda: list(itertools.islice(iterable, chunk_size)), [])
 
 
-def _fill_chunked(iterable, bucket_shape, empty_shape, dtype, bucket_size):
-    """Fill a numpy array from an iterable of unknown length using fixed-size buckets.
+def create_chunked(iterable, dtype, ncols=None, bucket_size=500):
+    """Create a numpy array from an iterable of indeterminate length.
 
-    Works for both 1D structured arrays (bucket_shape=(n,)) and 2D plain arrays
-    (bucket_shape=(n, ncols)).  Concatenates along axis=0 in both cases.
+    Needed when we can't determine the length of the iterable ahead of time
+    (e.g. for a generator or a database cursor), so can't create the complete
+    array in memory in one step.
+
+    Creates a list of arrays with ``bucket_size`` rows until ``iterable`` is
+    exhausted, then concatenates them along axis 0.
+
+    Pass ``ncols`` for a plain 2D array; omit it for a 1D structured array.
+
+    Args:
+        iterable: Iterable of data used to populate the array.
+        dtype: Numpy dtype of the created array.
+        ncols: Number of columns; if None, a 1D structured array is created.
+        bucket_size: Number of rows in each intermediate array.
+
+    Returns:
+        The created array. Returns a zero-length array if ``iterable`` has no data.
     """
+    bucket_shape = (bucket_size,) if ncols is None else (bucket_size, ncols)
+    empty_shape = (0,) if ncols is None else (0, ncols)
     arrays = []
     array = np.zeros(bucket_shape, dtype=dtype)
     for chunk in chunked(iterable, bucket_size):
@@ -43,28 +60,6 @@ def _fill_chunked(iterable, bucket_shape, empty_shape, dtype, bucket_size):
     # Needed because we return iterators for SQL databases
     # but don't know if e.g. sometimes a database has no biosphere exchanges.
     return np.concatenate(arrays, axis=0) if arrays else np.zeros(empty_shape, dtype=dtype)
-
-
-def create_chunked_structured_array(iterable, dtype, bucket_size=20000):
-    """Create a numpy structured array from an iterable of indeterminate length.
-
-    Needed when we can't determine the length of the iterable ahead of time
-    (e.g. for a generator or a database cursor), so can't create the complete
-    array in memory in one step.
-
-    Creates a list of arrays with ``bucket_size`` rows until ``iterable`` is
-    exhausted, then concatenates them.
-
-    Args:
-        iterable: Iterable of data used to populate the array.
-        dtype: Numpy dtype of the created array.
-        bucket_size: Number of rows in each intermediate array.
-
-    Returns:
-        Returns the created array. Will return a zero-length array if
-        ``iterable`` has no data.
-    """
-    return _fill_chunked(iterable, (bucket_size,), (0,), dtype, bucket_size)
 
 
 def create_structured_array(iterable, dtype, nrows=None, sort=False, sort_fields=None):
@@ -84,7 +79,7 @@ def create_structured_array(iterable, dtype, nrows=None, sort=False, sort_fields
             array[i] = tuple(row)
 
     else:
-        array = create_chunked_structured_array(iterable, dtype)
+        array = create_chunked(iterable, dtype)
 
     if sort:
         sort_fields = sort_fields or ()
@@ -95,29 +90,6 @@ def create_structured_array(iterable, dtype, nrows=None, sort=False, sort_fields
         array.sort(order=order)
 
     return array
-
-
-def create_chunked_array(iterable, ncols, dtype=np.float32, bucket_size=500):
-    """Create a numpy array from an iterable of indeterminate length.
-
-    Needed when we can't determine the length of the iterable ahead of time
-    (e.g. for a generator or a database cursor), so can't create the complete
-    array in memory in one step.
-
-    Creates a list of arrays with ``bucket_size`` rows until ``iterable`` is
-    exhausted, then concatenates them.
-
-    Args:
-        iterable: Iterable of data used to populate the array.
-        ncols: Number of columns in the created array.
-        dtype: Numpy dtype of the created array.
-        bucket_size: Number of rows in each intermediate array.
-
-    Returns:
-        Returns the created array. Will return a zero-length array if
-        ``iterable`` has no data.
-    """
-    return _fill_chunked(iterable, (bucket_size, ncols), (0, ncols), dtype, bucket_size)
 
 
 def create_array(iterable, nrows=None, dtype=np.float32):
@@ -145,6 +117,6 @@ def create_array(iterable, nrows=None, dtype=np.float32):
             ncols, data = get_ncols(iterable)
         except StopIteration:
             return np.zeros((0, 0), dtype=dtype)
-        array = create_chunked_array(data, ncols, dtype)
+        array = create_chunked(data, dtype, ncols=ncols)
 
     return array

--- a/tests/test_array_creation.py
+++ b/tests/test_array_creation.py
@@ -3,8 +3,7 @@ import numpy as np
 from bw_processing.array_creation import (
     chunked,
     create_array,
-    create_chunked_array,
-    create_chunked_structured_array,
+    create_chunked,
 )
 
 
@@ -41,58 +40,58 @@ def test_create_array_nonempty_generator():
     assert np.allclose(result[:, 1], [0, 2, 4, 6, 8])
 
 
-# --- create_chunked_array ---
+# --- create_chunked (plain 2D) ---
 
-def test_create_chunked_array_under_one_bucket():
+def test_create_chunked_under_one_bucket():
     data = [np.ones(3) * i for i in range(10)]
-    result = create_chunked_array(iter(data), ncols=3, bucket_size=500)
+    result = create_chunked(iter(data), np.float32, ncols=3, bucket_size=500)
     assert result.shape == (10, 3)
     assert np.allclose(result[7], [7, 7, 7])
 
 
-def test_create_chunked_array_multiple_full_buckets():
+def test_create_chunked_multiple_full_buckets():
     # Previously hstack joined on axis=1 → (bucket_size, ncols*n) instead of (total, ncols)
     data = [np.ones(3) * i for i in range(1000)]
-    result = create_chunked_array(iter(data), ncols=3, bucket_size=500)
+    result = create_chunked(iter(data), np.float32, ncols=3, bucket_size=500)
     assert result.shape == (1000, 3)
     assert np.allclose(result[0], [0, 0, 0])
     assert np.allclose(result[999], [999, 999, 999])
 
 
-def test_create_chunked_array_full_plus_partial_bucket():
+def test_create_chunked_full_plus_partial_bucket():
     # Previously hstack raised ValueError when a full and partial chunk were concatenated
     data = [np.ones(3) * i for i in range(600)]
-    result = create_chunked_array(iter(data), ncols=3, bucket_size=500)
+    result = create_chunked(iter(data), np.float32, ncols=3, bucket_size=500)
     assert result.shape == (600, 3)
     assert np.allclose(result[499], [499, 499, 499])
     assert np.allclose(result[599], [599, 599, 599])
 
 
-def test_create_chunked_array_empty():
-    result = create_chunked_array(iter([]), ncols=4, bucket_size=500)
+def test_create_chunked_empty_plain():
+    result = create_chunked(iter([]), np.float32, ncols=4, bucket_size=500)
     assert result.shape == (0, 4)
 
 
-# --- create_chunked_structured_array ---
+# --- create_chunked (structured 1D) ---
 
 SIMPLE_DTYPE = [("row", np.int32), ("col", np.int32), ("amount", np.float32)]
 
 
-def test_create_chunked_structured_array_under_one_bucket():
+def test_create_chunked_structured_under_one_bucket():
     data = [(i, i + 1, float(i)) for i in range(10)]
-    result = create_chunked_structured_array(iter(data), SIMPLE_DTYPE, bucket_size=20000)
+    result = create_chunked(iter(data), SIMPLE_DTYPE, bucket_size=20000)
     assert result.shape == (10,)
     assert list(result["row"]) == list(range(10))
 
 
-def test_create_chunked_structured_array_multiple_buckets():
+def test_create_chunked_structured_multiple_buckets():
     data = [(i, i + 1, float(i)) for i in range(500)]
-    result = create_chunked_structured_array(iter(data), SIMPLE_DTYPE, bucket_size=200)
+    result = create_chunked(iter(data), SIMPLE_DTYPE, bucket_size=200)
     assert result.shape == (500,)
     assert result["row"][0] == 0
     assert result["row"][499] == 499
 
 
-def test_create_chunked_structured_array_empty():
-    result = create_chunked_structured_array(iter([]), SIMPLE_DTYPE)
+def test_create_chunked_structured_empty():
+    result = create_chunked(iter([]), SIMPLE_DTYPE)
     assert result.shape == (0,)

--- a/tests/test_array_creation.py
+++ b/tests/test_array_creation.py
@@ -1,6 +1,11 @@
 import numpy as np
 
-from bw_processing.array_creation import chunked, create_array
+from bw_processing.array_creation import (
+    chunked,
+    create_array,
+    create_chunked_array,
+    create_chunked_structured_array,
+)
 
 
 def test_chunked():
@@ -34,3 +39,60 @@ def test_create_array_nonempty_generator():
     assert result.shape == (5, 2)
     assert np.allclose(result[:, 0], [0, 1, 2, 3, 4])
     assert np.allclose(result[:, 1], [0, 2, 4, 6, 8])
+
+
+# --- create_chunked_array ---
+
+def test_create_chunked_array_under_one_bucket():
+    data = [np.ones(3) * i for i in range(10)]
+    result = create_chunked_array(iter(data), ncols=3, bucket_size=500)
+    assert result.shape == (10, 3)
+    assert np.allclose(result[7], [7, 7, 7])
+
+
+def test_create_chunked_array_multiple_full_buckets():
+    # Previously hstack joined on axis=1 → (bucket_size, ncols*n) instead of (total, ncols)
+    data = [np.ones(3) * i for i in range(1000)]
+    result = create_chunked_array(iter(data), ncols=3, bucket_size=500)
+    assert result.shape == (1000, 3)
+    assert np.allclose(result[0], [0, 0, 0])
+    assert np.allclose(result[999], [999, 999, 999])
+
+
+def test_create_chunked_array_full_plus_partial_bucket():
+    # Previously hstack raised ValueError when a full and partial chunk were concatenated
+    data = [np.ones(3) * i for i in range(600)]
+    result = create_chunked_array(iter(data), ncols=3, bucket_size=500)
+    assert result.shape == (600, 3)
+    assert np.allclose(result[499], [499, 499, 499])
+    assert np.allclose(result[599], [599, 599, 599])
+
+
+def test_create_chunked_array_empty():
+    result = create_chunked_array(iter([]), ncols=4, bucket_size=500)
+    assert result.shape == (0, 4)
+
+
+# --- create_chunked_structured_array ---
+
+SIMPLE_DTYPE = [("row", np.int32), ("col", np.int32), ("amount", np.float32)]
+
+
+def test_create_chunked_structured_array_under_one_bucket():
+    data = [(i, i + 1, float(i)) for i in range(10)]
+    result = create_chunked_structured_array(iter(data), SIMPLE_DTYPE, bucket_size=20000)
+    assert result.shape == (10,)
+    assert list(result["row"]) == list(range(10))
+
+
+def test_create_chunked_structured_array_multiple_buckets():
+    data = [(i, i + 1, float(i)) for i in range(500)]
+    result = create_chunked_structured_array(iter(data), SIMPLE_DTYPE, bucket_size=200)
+    assert result.shape == (500,)
+    assert result["row"][0] == 0
+    assert result["row"][499] == 499
+
+
+def test_create_chunked_structured_array_empty():
+    result = create_chunked_structured_array(iter([]), SIMPLE_DTYPE)
+    assert result.shape == (0,)


### PR DESCRIPTION
## Summary

Collapses `create_chunked_structured_array` and `create_chunked_array` into a single public `create_chunked` function, and fixes two bugs that existed in the old implementations:

- **`create_chunked(iterable, dtype, ncols=None, bucket_size=500)`** handles both cases:
  - Omit `ncols` → 1D structured array
  - Pass `ncols` → plain 2D array
- The two old functions (and the intermediate `_fill_chunked` helper) are removed entirely.

### Bugs fixed

- **#95** — The old `create_chunked_array` used `np.hstack`, which for 2D arrays concatenates on `axis=1` (columns) instead of `axis=0` (rows). Any input longer than `bucket_size` rows silently produced the wrong shape, or raised `ValueError` when a full and partial chunk were combined. `create_chunked` uses `np.concatenate(arrays, axis=0)`, which is correct for both shapes.
- **#97** — The partial (final) chunk slice `array[:i+1]` was a NumPy view, keeping the full pre-allocated bucket buffer alive until the final concatenation. `create_chunked` calls `.copy()` on the slice to release the oversized allocation immediately.

Closes #98. Also fixes #95 and #97.

## Test plan

- [x] `test_create_chunked_multiple_full_buckets` — shape is `(1000, 3)`, not `(500, 6)`
- [x] `test_create_chunked_full_plus_partial_bucket` — no `ValueError` when combining differently-sized chunks
- [x] `test_create_chunked_under_one_bucket` / `test_create_chunked_empty_plain`
- [x] `test_create_chunked_structured_multiple_buckets` / `_under_one_bucket` / `_empty`
- [x] All previously passing tests continue to pass (211/211)