### PR TITLE
Prune redundant distributions arrays in finalize_serialization

### DIFF
--- a/src/bw_processing/datapackage.py
+++ b/src/bw_processing/datapackage.py
@@ -8,6 +8,12 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 if TYPE_CHECKING:
     from bw_processing.matrix_entry import MatrixEntry
 
+try:
+    from stats_arrays import NoUncertainty, UndefinedUncertainty
+    _NO_UNCERTAINTY_IDS = (NoUncertainty.id, UndefinedUncertainty.id)
+except ImportError:
+    _NO_UNCERTAINTY_IDS = (0, 1)
+
 import numpy as np
 import pandas as pd
 from fsspec import AbstractFileSystem
@@ -384,6 +390,59 @@ class Datapackage(DatapackageBase):
 
         self.data = []
 
+    def _prune_trivial_distributions(self) -> None:
+        """Remove distributions resources that carry no information beyond the data array.
+
+        A distributions resource is considered trivial when every row has an
+        ``uncertainty_type`` of 0 (no uncertainty) or 1 (unknown uncertainty)
+        *and* the ``loc`` values are equal to the corresponding data-array
+        amounts (at float32 precision).  Such a resource duplicates what the
+        data array already encodes, so it is deleted from the filesystem and
+        removed from ``self.data`` / ``self.resources``.
+        """
+        to_remove = []
+
+        for idx, resource in enumerate(self.resources):
+            if resource.get("kind") != "distributions":
+                continue
+
+            group = resource.get("group")
+            if group is None:
+                continue
+
+            data_idx = next(
+                (
+                    i
+                    for i, r in enumerate(self.resources)
+                    if r.get("group") == group and r.get("kind") == "data"
+                ),
+                None,
+            )
+            if data_idx is None:
+                continue
+
+            dist_arr = self.data[idx]
+            if isinstance(dist_arr, (Proxy, partial)):
+                dist_arr = dist_arr()
+
+            data_arr = self.data[data_idx]
+            if isinstance(data_arr, (Proxy, partial)):
+                data_arr = data_arr()
+
+            all_trivial = np.all(np.isin(dist_arr["uncertainty_type"], _NO_UNCERTAINTY_IDS))
+            loc_matches = np.array_equal(dist_arr["loc"], data_arr.astype(np.float32))
+
+            if all_trivial and loc_matches:
+                to_remove.append(idx)
+
+        for idx in sorted(to_remove, reverse=True):
+            try:
+                self.fs.rm(self.resources[idx]["path"])
+            except (KeyError, FileNotFoundError):
+                pass
+            del self.resources[idx]
+            del self.data[idx]
+
     def finalize_serialization(self) -> None:
         """Write the metadata file and close the filesystem.
 
@@ -402,6 +461,7 @@ class Datapackage(DatapackageBase):
             raise ValueError("In-memory file systems can't be serialized")
 
         self._dehydrate_interfaces()
+        self._prune_trivial_distributions()
         self._check_length_consistency()
 
         file_writer(

--- a/tests/test_datapackage.py
+++ b/tests/test_datapackage.py
@@ -643,6 +643,145 @@ def test_add_dynamic_array_scale_shapemismatch():
         )
 
 
+def _add_vector_with_distributions(dp, name, data_array, indices_array, distributions_array):
+    """Add a resource group including a distributions array, bypassing
+    add_persistent_vector's early-exit filter.  Used to set up test state
+    that _prune_trivial_distributions is meant to clean up."""
+    kwargs = {"matrix": "m", "category": "vector", "nrows": len(indices_array)}
+    dp._add_numpy_array_resource(
+        array=indices_array, name=name + ".indices", group=name, kind="indices",
+        meta_object="vector", meta_type="indices", **kwargs,
+    )
+    dp._add_numpy_array_resource(
+        array=data_array, name=name + ".data", group=name, kind="data",
+        meta_object="vector", meta_type="generic", **kwargs,
+    )
+    dp._add_numpy_array_resource(
+        array=distributions_array, name=name + ".distributions", group=name, kind="distributions",
+        meta_object="vector", meta_type="distributions", **kwargs,
+    )
+
+
+def test_finalize_removes_trivial_distributions_type0(tmp_path):
+    """uncertainty_type=0 with loc==amount → distributions resource must be pruned."""
+    data_array = np.array([1.0, 2.0, 3.0], dtype=np.float32)
+    indices_array = np.array([(1, 4), (2, 5), (3, 6)], dtype=INDICES_DTYPE)
+    distributions_array = np.array(
+        [(0, 1.0, np.nan, np.nan, np.nan, np.nan, False),
+         (0, 2.0, np.nan, np.nan, np.nan, np.nan, False),
+         (0, 3.0, np.nan, np.nan, np.nan, np.nan, False)],
+        dtype=UNCERTAINTY_DTYPE,
+    )
+
+    dp = create_datapackage(fs=generic_directory_filesystem(dirpath=tmp_path), name="test")
+    _add_vector_with_distributions(dp, "r", data_array, indices_array, distributions_array)
+    dp.finalize_serialization()
+
+    dp2 = load_datapackage(generic_directory_filesystem(dirpath=tmp_path))
+    assert "distributions" not in {r["kind"] for r in dp2.resources}
+
+
+def test_finalize_removes_trivial_distributions_type1(tmp_path):
+    """uncertainty_type=1 with loc==amount is also trivial and must be pruned."""
+    data_array = np.array([5.0, 6.0], dtype=np.float32)
+    indices_array = np.array([(1, 4), (2, 5)], dtype=INDICES_DTYPE)
+    distributions_array = np.array(
+        [(1, 5.0, np.nan, np.nan, np.nan, np.nan, False),
+         (1, 6.0, np.nan, np.nan, np.nan, np.nan, False)],
+        dtype=UNCERTAINTY_DTYPE,
+    )
+
+    dp = create_datapackage(fs=generic_directory_filesystem(dirpath=tmp_path), name="test")
+    _add_vector_with_distributions(dp, "r", data_array, indices_array, distributions_array)
+    dp.finalize_serialization()
+
+    dp2 = load_datapackage(generic_directory_filesystem(dirpath=tmp_path))
+    assert "distributions" not in {r["kind"] for r in dp2.resources}
+
+
+def test_finalize_removes_trivial_distributions_file_deleted(tmp_path):
+    """The .distributions.npy file must be physically removed from disk."""
+    data_array = np.array([1.0, 2.0], dtype=np.float32)
+    indices_array = np.array([(1, 4), (2, 5)], dtype=INDICES_DTYPE)
+    distributions_array = np.array(
+        [(0, 1.0, np.nan, np.nan, np.nan, np.nan, False),
+         (0, 2.0, np.nan, np.nan, np.nan, np.nan, False)],
+        dtype=UNCERTAINTY_DTYPE,
+    )
+
+    dp = create_datapackage(fs=generic_directory_filesystem(dirpath=tmp_path), name="test")
+    _add_vector_with_distributions(dp, "r", data_array, indices_array, distributions_array)
+    dist_path = tmp_path / "r.distributions.npy"
+    assert dist_path.exists()
+    dp.finalize_serialization()
+    assert not dist_path.exists()
+
+
+def test_finalize_keeps_distributions_real_uncertainty(tmp_path):
+    """uncertainty_type>=2 must be retained even if loc==amount."""
+    data_array = np.array([1.0, 2.0, 3.0], dtype=np.float32)
+    indices_array = np.array([(1, 4), (2, 5), (3, 6)], dtype=INDICES_DTYPE)
+    distributions_array = np.array(
+        [(2, 1.0, 0.5, np.nan, np.nan, np.nan, False),
+         (2, 2.0, 0.5, np.nan, np.nan, np.nan, False),
+         (2, 3.0, 0.5, np.nan, np.nan, np.nan, False)],
+        dtype=UNCERTAINTY_DTYPE,
+    )
+
+    dp = create_datapackage(fs=generic_directory_filesystem(dirpath=tmp_path), name="test")
+    _add_vector_with_distributions(dp, "r", data_array, indices_array, distributions_array)
+    dp.finalize_serialization()
+
+    dp2 = load_datapackage(generic_directory_filesystem(dirpath=tmp_path))
+    assert "distributions" in {r["kind"] for r in dp2.resources}
+
+
+def test_finalize_keeps_distributions_loc_mismatch(tmp_path):
+    """All uncertainty_type=0/1 but loc!=amount → must be retained."""
+    data_array = np.array([1.0, 2.0, 3.0], dtype=np.float32)
+    indices_array = np.array([(1, 4), (2, 5), (3, 6)], dtype=INDICES_DTYPE)
+    distributions_array = np.array(
+        [(0, 1.0, np.nan, np.nan, np.nan, np.nan, False),
+         (0, 9.0, np.nan, np.nan, np.nan, np.nan, False),  # loc != amount
+         (0, 3.0, np.nan, np.nan, np.nan, np.nan, False)],
+        dtype=UNCERTAINTY_DTYPE,
+    )
+
+    dp = create_datapackage(fs=generic_directory_filesystem(dirpath=tmp_path), name="test")
+    _add_vector_with_distributions(dp, "r", data_array, indices_array, distributions_array)
+    dp.finalize_serialization()
+
+    dp2 = load_datapackage(generic_directory_filesystem(dirpath=tmp_path))
+    assert "distributions" in {r["kind"] for r in dp2.resources}
+
+
+def test_finalize_mixed_groups_prunes_only_trivial(tmp_path):
+    """Two groups: trivial distributions pruned, real distributions kept."""
+    indices_array = np.array([(1, 4), (2, 5)], dtype=INDICES_DTYPE)
+    data_array = np.array([1.0, 2.0], dtype=np.float32)
+
+    trivial_dist = np.array(
+        [(0, 1.0, np.nan, np.nan, np.nan, np.nan, False),
+         (0, 2.0, np.nan, np.nan, np.nan, np.nan, False)],
+        dtype=UNCERTAINTY_DTYPE,
+    )
+    real_dist = np.array(
+        [(3, 1.0, 0.2, np.nan, np.nan, np.nan, False),
+         (3, 2.0, 0.2, np.nan, np.nan, np.nan, False)],
+        dtype=UNCERTAINTY_DTYPE,
+    )
+
+    dp = create_datapackage(fs=generic_directory_filesystem(dirpath=tmp_path), name="test")
+    _add_vector_with_distributions(dp, "trivial", data_array, indices_array, trivial_dist)
+    _add_vector_with_distributions(dp, "real", data_array, indices_array, real_dist)
+    dp.finalize_serialization()
+
+    dp2 = load_datapackage(generic_directory_filesystem(dirpath=tmp_path))
+    dist_resources = [r for r in dp2.resources if r["kind"] == "distributions"]
+    assert len(dist_resources) == 1
+    assert dist_resources[0]["group"] == "real"
+
+
 def test_scale_array_parquet_roundtrip(tmp_path):
     scale_array = np.array([0.5, 1.0, 2.0])
     indices_array = np.array([(1, 4), (2, 5), (3, 6)], dtype=INDICES_DTYPE)


### PR DESCRIPTION
## Summary

- Adds `_prune_trivial_distributions()`, called from `finalize_serialization()`, which removes a distributions resource when it carries no stochastic information beyond what the data array already encodes
- A distributions resource is considered trivial when **all** rows satisfy both conditions:
  1. `uncertainty_type` is a no-information ID (`NoUncertainty` or `UndefinedUncertainty` from `stats_arrays`; falls back to `0` and `1` when `stats_arrays` is not installed, following the same pattern already used in `matrix_entry.py`)
  2. `loc` equals the corresponding data-array amount (compared at `float32` precision, the dtype of the `loc` field)
- Both the in-memory resource entry and the on-disk file are deleted before `datapackage.json` is written, so reloaded packages are clean

## Notes

- `stats_arrays` is not a declared dependency of this package; the import is wrapped in `try/except ImportError` identical to the existing pattern in `matrix_entry.py`
- The `add_persistent_vector` method already declines to store distributions arrays where *all* types are trivial (line ~573). `_prune_trivial_distributions` is a complementary defence for arrays that arrive through other code paths — e.g. loaded from an older datapackage file and then re-serialized

## Test plan

- [ ] `test_finalize_removes_trivial_distributions_type0` — type 0 + loc==amount → pruned
- [ ] `test_finalize_removes_trivial_distributions_type1` — type 1 + loc==amount → pruned
- [ ] `test_finalize_removes_trivial_distributions_file_deleted` — `.npy` file is physically removed from disk
- [ ] `test_finalize_keeps_distributions_real_uncertainty` — any type ≥ 2 → retained
- [ ] `test_finalize_keeps_distributions_loc_mismatch` — all trivial types but loc≠amount → retained
- [ ] `test_finalize_mixed_groups_prunes_only_trivial` — two groups: only the trivial one is pruned
- [ ] Full test suite: 50/50 passing, no regressions