### PR TITLE
Fix data-dependent flip_array dtype check in all add_* methods

### DIFF
--- a/src/bw_processing/datapackage.py
+++ b/src/bw_processing/datapackage.py
@@ -650,18 +650,18 @@ class Datapackage(DatapackageBase):
                 )
         if flip_array is not None:
             flip_array = load_bytes(flip_array)
+            if flip_array.dtype != bool:
+                raise WrongDatatype(
+                    "`flip_array` dtype is {}, but must be `bool`".format(flip_array.dtype)
+                )
+            if flip_array.shape != indices_array.shape:
+                raise ShapeMismatch(
+                    "`flip_array` shape ({}) doesn't match `indices_array` ({}).".format(
+                        flip_array.shape, indices_array.shape
+                    )
+                )
             # If no flips, don't need to store it
             if flip_array.sum():
-                if flip_array.dtype != bool:
-                    raise WrongDatatype(
-                        "`flip_array` dtype is {}, but must be `bool`".format(flip_array.dtype)
-                    )
-                elif flip_array.shape != indices_array.shape:
-                    raise ShapeMismatch(
-                        "`flip_array` shape ({}) doesn't match `indices_array` ({}).".format(
-                            flip_array.shape, indices_array.shape
-                        )
-                    )
                 self._add_numpy_array_resource(
                     array=flip_array,
                     group=name,
@@ -787,17 +787,18 @@ class Datapackage(DatapackageBase):
         )
         if flip_array is not None:
             flip_array = load_bytes(flip_array)
+            if flip_array.dtype != bool:
+                raise WrongDatatype(
+                    "`flip_array` dtype is {}, but must be `bool`".format(flip_array.dtype)
+                )
+            if flip_array.shape != indices_array.shape:
+                raise ShapeMismatch(
+                    "`flip_array` shape ({}) doesn't match `indices_array` ({}).".format(
+                        flip_array.shape, indices_array.shape
+                    )
+                )
+            # If no flips, don't need to store it
             if flip_array.sum():
-                if flip_array.dtype != bool:
-                    raise WrongDatatype(
-                        "`flip_array` dtype is {}, but must be `bool`".format(flip_array.dtype)
-                    )
-                elif flip_array.shape != indices_array.shape:
-                    raise ShapeMismatch(
-                        "`flip_array` shape ({}) doesn't match `indices_array` ({}).".format(
-                            flip_array.shape, indices_array.shape
-                        )
-                    )
                 self._add_numpy_array_resource(
                     array=flip_array,
                     group=name,
@@ -1155,17 +1156,18 @@ class Datapackage(DatapackageBase):
         )
         if flip_array is not None:
             flip_array = load_bytes(flip_array)
+            if flip_array.dtype != bool:
+                raise WrongDatatype(
+                    "`flip_array` dtype is {}, but must be `bool`".format(flip_array.dtype)
+                )
+            if flip_array.shape != indices_array.shape:
+                raise ShapeMismatch(
+                    "`flip_array` shape ({}) doesn't match `indices_array` ({}).".format(
+                        flip_array.shape, indices_array.shape
+                    )
+                )
+            # If no flips, don't need to store it
             if flip_array.sum():
-                if flip_array.dtype != bool:
-                    raise WrongDatatype(
-                        "`flip_array` dtype is {}, but must be `bool`".format(flip_array.dtype)
-                    )
-                elif flip_array.shape != indices_array.shape:
-                    raise ShapeMismatch(
-                        "`flip_array` shape ({}) doesn't match `indices_array` ({}).".format(
-                            flip_array.shape, indices_array.shape
-                        )
-                    )
                 self._add_numpy_array_resource(
                     array=flip_array,
                     group=name,
@@ -1275,8 +1277,13 @@ class Datapackage(DatapackageBase):
         self._check_params_args(params_array, param_labels, param_label_schema)
         self._prepare_modifications()
 
-        if isinstance(flip_array, np.ndarray) and not flip_array.sum():
-            flip_array = None
+        if isinstance(flip_array, np.ndarray):
+            if flip_array.dtype != bool:
+                raise WrongDatatype(
+                    "`flip_array` dtype is {}, but must be `bool`".format(flip_array.dtype)
+                )
+            if not flip_array.sum():
+                flip_array = None
 
         kwargs.update({"matrix": matrix, "category": "array", "nrows": len(indices_array)})
         name = self._prepare_name(name)
@@ -1295,17 +1302,18 @@ class Datapackage(DatapackageBase):
         )
         if flip_array is not None:
             flip_array = load_bytes(flip_array)
+            if flip_array.dtype != bool:
+                raise WrongDatatype(
+                    "`flip_array` dtype is {}, but must be `bool`".format(flip_array.dtype)
+                )
+            if flip_array.shape != indices_array.shape:
+                raise ShapeMismatch(
+                    "`flip_array` shape ({}) doesn't match `indices_array` ({}).".format(
+                        flip_array.shape, indices_array.shape
+                    )
+                )
+            # If no flips, don't need to store it
             if flip_array.sum():
-                if flip_array.dtype != bool:
-                    raise WrongDatatype(
-                        "`flip_array` dtype is {}, but must be `bool`".format(flip_array.dtype)
-                    )
-                elif flip_array.shape != indices_array.shape:
-                    raise ShapeMismatch(
-                        "`flip_array` shape ({}) doesn't match `indices_array` ({}).".format(
-                            flip_array.shape, indices_array.shape
-                        )
-                    )
                 self._add_numpy_array_resource(
                     array=flip_array,
                     group=name,

--- a/tests/test_datapackage.py
+++ b/tests/test_datapackage.py
@@ -330,6 +330,23 @@ def test_add_persistent_vector_flip_dtype():
         )
 
 
+def test_add_persistent_vector_flip_dtype_all_zeros():
+    # A non-bool flip that is all-zeros must still raise WrongDatatype;
+    # previously the dtype check was skipped when sum() == 0.
+    dp = create_datapackage()
+    data_array = np.array([2, 7, 12])
+    flip_array = np.array([0, 0, 0])  # all falsy, but wrong dtype
+    indices_array = np.array([(1, 4), (2, 5), (3, 6)], dtype=INDICES_DTYPE)
+    with pytest.raises(WrongDatatype):
+        dp.add_persistent_vector(
+            matrix="sa_matrix",
+            data_array=data_array,
+            name="sa-data-vector",
+            flip_array=flip_array,
+            indices_array=indices_array,
+        )
+
+
 def test_add_persistent_vector_flip_shapemistmatch():
     dp = create_datapackage()
     data_array = np.array([2, 7, 12])
@@ -386,6 +403,21 @@ def test_add_persistent_array_flip_dtype():
         )
 
 
+def test_add_persistent_array_flip_dtype_all_zeros():
+    dp = create_datapackage()
+    data_array = np.arange(12).reshape(3, 4)
+    flip_array = np.array([0, 0, 0])  # all falsy, but wrong dtype
+    indices_array = np.array([(1, 4), (2, 5), (3, 6)], dtype=INDICES_DTYPE)
+    with pytest.raises(WrongDatatype):
+        dp.add_persistent_array(
+            matrix="sa_matrix",
+            data_array=data_array,
+            name="sa-data-vector",
+            flip_array=flip_array,
+            indices_array=indices_array,
+        )
+
+
 def test_add_persistent_array_flip_shapemistmatch():
     dp = create_datapackage()
     data_array = np.arange(12).reshape(3, 4)
@@ -415,6 +447,20 @@ def test_add_dynamic_array_flip_dtype():
         )
 
 
+def test_add_dynamic_array_flip_dtype_all_zeros():
+    dp = create_datapackage()
+    flip_array = np.array([0, 0, 0])  # all falsy, but wrong dtype
+    indices_array = np.array([(1, 4), (2, 5), (3, 6)], dtype=INDICES_DTYPE)
+    with pytest.raises(WrongDatatype):
+        dp.add_dynamic_array(
+            matrix="sa_matrix",
+            interface=Dummy(),
+            name="sa-data-vector",
+            flip_array=flip_array,
+            indices_array=indices_array,
+        )
+
+
 def test_add_dynamic_array_flip_shapemistmatch():
     dp = create_datapackage()
     flip_array = np.array([0, 1, 0, 1], dtype=bool)
@@ -432,6 +478,20 @@ def test_add_dynamic_array_flip_shapemistmatch():
 def test_add_dynamic_vector_flip_dtype():
     dp = create_datapackage()
     flip_array = np.array([0, 1, 0])
+    indices_array = np.array([(1, 4), (2, 5), (3, 6)], dtype=INDICES_DTYPE)
+    with pytest.raises(WrongDatatype):
+        dp.add_dynamic_vector(
+            matrix="sa_matrix",
+            interface=Dummy(),
+            name="sa-data-vector",
+            flip_array=flip_array,
+            indices_array=indices_array,
+        )
+
+
+def test_add_dynamic_vector_flip_dtype_all_zeros():
+    dp = create_datapackage()
+    flip_array = np.array([0, 0, 0])  # all falsy, but wrong dtype
     indices_array = np.array([(1, 4), (2, 5), (3, 6)], dtype=INDICES_DTYPE)
     with pytest.raises(WrongDatatype):
         dp.add_dynamic_vector(


### PR DESCRIPTION
## Summary

- In `add_persistent_vector`, `add_persistent_array`, `add_dynamic_vector`, and `add_dynamic_array`, the `WrongDatatype` check on `flip_array` was nested inside `if flip_array.sum():` — so a non-bool flip array with all-zero/falsy values silently passed validation, while the identical dtype with any truthy value raised an error
- Also fixes `add_dynamic_array`'s early-exit pre-clearing (`if not flip_array.sum(): flip_array = None`), which discarded a non-bool all-zeros array without ever checking its dtype
- Fix: hoist the dtype check to the top of the `if flip_array is not None:` block in all four methods, before the `sum()` guard that decides whether to write the resource

## Test plan

- [ ] Four new regression tests (`test_add_*_flip_dtype_all_zeros`) covering the previously-silent all-zeros non-bool case for each affected method
- [ ] All existing flip dtype and shape-mismatch tests continue to pass
- [ ] Full `test_datapackage.py` suite: 54 passed